### PR TITLE
auto switch fan profiles depending on charging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a very simple Python service for Linux that drives the FrameWork laptop's fan speed according to a configurable speed/temp curve.
 Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
-
+Its possible to specfify two separate fan curves depending on whether the Laptop is charging/discharging.
 Under the hood, it uses [fw-ectool](https://github.com/DHowett/fw-ectool) to change parameters in FrameWork's embedded controller (EC).
 
 # Install
@@ -39,7 +39,8 @@ sudo service fw-fanctrl restart
 
 It contains different strategies, ranked from the most silent to the noisiest. You can add new strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this repo :)
 
-The strategy that will be run is the one stored in the `defaultStrategy` entry.
+The strategy that will be run during charging is the one stored in the `defaultStrategy` entry.
+The separate strategy during discharge is optional. It is stored in the `strategyOnDischarging` entry. If none is specified only the `defaultStrategy is used.
 
 Strategies can be configured with the following parameters:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # fw-fanctrl
 
-This is a very simple Python service for Linux that drives the FrameWork laptop's fan speed according to a configurable speed/temp curve.
+This is a very simple Python service for Linux that drives the Framework Laptop's fan speed according to a configurable speed/temp curve.
 Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
 Its possible to specfify two separate fan curves depending on whether the Laptop is charging/discharging.
 Under the hood, it uses [fw-ectool](https://github.com/DHowett/fw-ectool) to change parameters in FrameWork's embedded controller (EC).
+This is a fork of the [original version](https://github.com/TamtamHero/fw-fanctrl.git) of fw-fanctrl, which provides the same functionality without the automatic switching.
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple Python service for Linux that drives the Framework Laptop's fan speed according to a configurable speed/temp curve.
 Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
-Its possible to specfify two separate fan curves depending on whether the Laptop is charging/discharging.
+Its possible to specify two separate fan curves depending on whether the Laptop is charging/discharging.
 Under the hood, it uses [fw-ectool](https://github.com/DHowett/fw-ectool) to change parameters in FrameWork's embedded controller (EC).
 This is a fork of the [original version](https://github.com/TamtamHero/fw-fanctrl.git) of fw-fanctrl. The orginal version provides the same functionality without the automatic switching of fan curves.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fw-fanctrl
 
-This is a very simple Python service for Linux that drives the Framework Laptop's fan speed according to a configurable speed/temp curve.
+This is a simple Python service for Linux that drives the Framework Laptop's fan speed according to a configurable speed/temp curve.
 Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
 Its possible to specfify two separate fan curves depending on whether the Laptop is charging/discharging.
 Under the hood, it uses [fw-ectool](https://github.com/DHowett/fw-ectool) to change parameters in FrameWork's embedded controller (EC).
@@ -17,11 +17,11 @@ yes | sudo sensors-detect
 
 To communicate with the embedded controller the `fw-ectool` is needed. You can either use the pre-compiled executable of `fw-ectool` in this repo, or recompile one from [this repo](https://github.com/DHowett/fw-ectool) and copy it in `./bin`.
 
-The charging status of the battery is fetched from the following file:
-`/sys/class/hwmon/hwmon2/device/status`
-Make sure the charging status is stored under the same path on your machine. Otherwise edit the `fw-fanctrl.py` script.
+The charging status of the battery is fetched from the following file by default:
+`/sys/class/power_supply/BAT1/status`
+The default path can be overwritten by entering a value for `batteryChargingStatusPath` inside the `config.json` file.
 
-Then, simply run:
+Then run:
 ```
 sudo ./install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo service fw-fanctrl restart
 It contains different strategies, ranked from the most silent to the noisiest. You can add new strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this repo :)
 
 The strategy that will be run during charging is the one stored in the `defaultStrategy` entry.
-The separate strategy during discharge is optional. It is stored in the `strategyOnDischarging` entry. If none is specified only the `defaultStrategy is used.
+The separate strategy during discharge is optional. It is stored in the `strategyOnDischarging` entry. If none is specified only the `defaultStrategy` is used.
 
 Strategies can be configured with the following parameters:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ sudo apt install lm-sensors
 yes | sudo sensors-detect
 ```
 
-You can either use the pre-compiled executable of `fw-ectool` in this repo, or recompile one from [this repo](https://github.com/DHowett/fw-ectool) and copy it in `./bin`.
+To communicate with the embedded controller the `fw-ectool` is needed. You can either use the pre-compiled executable of `fw-ectool` in this repo, or recompile one from [this repo](https://github.com/DHowett/fw-ectool) and copy it in `./bin`.
+
+The charging status of the battery is fetched from the following file:
+`/sys/class/hwmon/hwmon2/device/status`
+Make sure the charging status is stored under the same path on your machine. Otherwise edit the `fw-fanctrl.py` script.
 
 Then, simply run:
 ```
@@ -39,8 +43,7 @@ sudo service fw-fanctrl restart
 
 It contains different strategies, ranked from the most silent to the noisiest. You can add new strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this repo :)
 
-The strategy that will be run during charging is the one stored in the `defaultStrategy` entry.
-The separate strategy during discharge is optional. It is stored in the `strategyOnDischarging` entry. If none is specified only the `defaultStrategy` is used.
+The strategy active by default is the one specified in the `defaultStrategy` entry. Additionally a separate strategy can be defined, which is only active during discharge of the battery. This one is optional and specified `strategyOnDischarging` entry. If none is specified only the `defaultStrategy` is used.
 
 Strategies can be configured with the following parameters:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a very simple Python service for Linux that drives the Framework Laptop'
 Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
 Its possible to specfify two separate fan curves depending on whether the Laptop is charging/discharging.
 Under the hood, it uses [fw-ectool](https://github.com/DHowett/fw-ectool) to change parameters in FrameWork's embedded controller (EC).
-This is a fork of the [original version](https://github.com/TamtamHero/fw-fanctrl.git) of fw-fanctrl, which provides the same functionality without the automatic switching.
+This is a fork of the [original version](https://github.com/TamtamHero/fw-fanctrl.git) of fw-fanctrl. The orginal version provides the same functionality without the automatic switching of fan curves.
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo service fw-fanctrl restart
 
 It contains different strategies, ranked from the most silent to the noisiest. You can add new strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this repo :)
 
-The strategy active by default is the one specified in the `defaultStrategy` entry. Additionally a separate strategy can be defined, which is only active during discharge of the battery. This one is optional and specified `strategyOnDischarging` entry. If none is specified only the `defaultStrategy` is used.
+The strategy active by default is the one specified in the `defaultStrategy` entry. Additionally a separate strategy can be defined, which is only active during discharge of the battery. This one is optional and specified in the `strategyOnDischarging` entry. If none is given only the `defaultStrategy` is used.
 
 Strategies can be configured with the following parameters:
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "defaultStrategy": "lazy",
+    "strategyOnDischarging" : "lazyest",
     "strategies": {
         "lazyest": {
             "fanSpeedUpdateFrequency": 5,

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "defaultStrategy": "medium",
     "strategyOnDischarging" : "lazyest",
+    "batteryChargingStatusPath" : "",
     "strategies": {
         "lazyest": {
             "fanSpeedUpdateFrequency": 5,

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "defaultStrategy": "lazy",
+    "defaultStrategy": "medium",
     "strategyOnDischarging" : "lazyest",
     "strategies": {
         "lazyest": {

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -20,7 +20,6 @@ class FanController:
         if strategy == "":
             strategy = config["defaultStrategy"]
         strategy = config["strategies"][strategy]
-        self.switchOnDischarging = config["switchOnDischarging"]
         self.strategyOnDischarging = config["strategyOnDischarging"]
         self.speedCurve = strategy["speedCurve"]
         self.fanSpeedUpdateFrequency = strategy["fanSpeedUpdateFrequency"]

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -12,6 +12,7 @@ class FanController:
     speed = 0
     temps = [0] * 100
     _tempIndex = 0
+    discharging = False
 
     def __init__(self, configPath, strategy):
         with open(configPath, "r") as fp:
@@ -19,6 +20,8 @@ class FanController:
         if strategy == "":
             strategy = config["defaultStrategy"]
         strategy = config["strategies"][strategy]
+        self.switchOnDischarging = config["switchOnDischarging"]
+        self.strategyOnDischarging = config["strategyOnDischarging"]
         self.speedCurve = strategy["speedCurve"]
         self.fanSpeedUpdateFrequency = strategy["fanSpeedUpdateFrequency"]
         self.movingAverageInterval = strategy["movingAverageInterval"]
@@ -81,6 +84,16 @@ class FanController:
         for i in range(0, timeInterval):
             tempSum += self.temps[self._tempIndex - i]
         return tempSum / timeInterval
+    
+    # determine whether the battery is charging or discharging
+    # changing the strategy is not yet part of the code - help required
+    def getBatteryDischargingStatus():
+        with open("/sys/class/hwmon/hwmon2/device/status", "r") as fb:
+            batteryStatus = fb.readline().rstrip('\n')
+            if batteryStatus == "Discharging":
+                self.discharging = True
+            elif batteryStatus == "Charging":
+                self.discharging = False
 
     def printState(self):
         print(


### PR DESCRIPTION
This updated version enables the automatic switch between two different fan curves depending on whether the Laptop is charging or discharging.
There are two new functions: `updateStrategy` and `getBatteryChargingStatus`. UpdateStrategy is called from once from __init__ and regularly from run(). UpdateStrategy then calls getBatteryChargingStatus. getBatteryChargingStatus checks whether the charging status changed, compared to the last look up. It returns either no change, or the new charging status. updateStrategy only loads a new fan curve if the charging status changed.
The `config.json file is only read once, during `__init__`. The config.json file contains a new key "strategyOnDischarging". The user is supposed to enter one of the defined fan curves which should be active during discharge. If no separate discharge strategy is specified, the tool uses the same strategy as for charging.

Info: this is my first Github pull request. Any feedback is appreciated. Only the changes from 19.08.2022. are relevant. The ones from 18.08. are me fuzzing around.