### PR TITLE
Fix startup issue

### DIFF
--- a/fanctrl.py
+++ b/fanctrl.py
@@ -142,6 +142,11 @@ class FanController:
                 executable="/bin/bash",
             ).stdout
         )
+
+        # sensors -j does not return the core temperatures at startup
+        if "coretemp-isa-0000" not in sensorsOutput.keys():
+            return
+
         cores = 0
         for k, v in sensorsOutput["coretemp-isa-0000"].items():
             if k.startswith("Core "):


### PR DESCRIPTION
On my system when I turn on my laptop, the ```sensors -j``` does not return ```coretemp-isa-0000``` key as expected (After I log in I can see that it returns the data as expected). Which results in a failed service and it stays failed unless I restart the service manually. This change will resolve this issue by early returning from the ```updateTemperature``` function if the desired output was not captured.