### PR TITLE
Fix core temp reading for 12th gen

### DIFF
--- a/fanctrl.py
+++ b/fanctrl.py
@@ -156,7 +156,7 @@ class FanController:
             if k.startswith("Core "):
                 i = int(k.split(" ")[1])
                 cores += 1
-                sumCoreTemps += float(v["temp" + str(i + 2) + "_input"])
+                sumCoreTemps += float(v[[key for key in v.keys() if key.endswith("_input")][0]])
 
         self._tempIndex = (self._tempIndex + 1) % len(self.temps)
         self.temps[self._tempIndex] = sumCoreTemps / cores


### PR DESCRIPTION
Core numbers within "sensors" output seem to be somewhat inconsistent which leads to errors and ultimately a not working fan control. It tried to mitigate this by just getting the temp<x>_input field of every core without "guessing" the core number.

This fixes it for me, might be helpful to others