### PR TITLE
fix: Crash when initial battery state is "Not charging"

### DIFF
--- a/fanctrl.py
+++ b/fanctrl.py
@@ -100,12 +100,11 @@ class FanController:
 
             if currentBatteryStatus == self.lastBatteryStatus:
                 return 0  # battery charging status hasnt change - dont switch fan curve
-            elif currentBatteryStatus != self.lastBatteryStatus:
-                self.lastBatteryStatus = currentBatteryStatus
-                if currentBatteryStatus == "Charging":
-                    return 1
-                elif currentBatteryStatus == "Discharging":
-                    return 2
+            self.lastBatteryStatus = currentBatteryStatus
+            if currentBatteryStatus == "Discharging":
+                return 2
+            # Battery is not discharging
+            return 1
 
     def setSpeed(self, speed):
         self.speed = speed


### PR DESCRIPTION
Fixed crash when the battery status at startup was `Not Charging`