### PR TITLE
Return "sensors -j" to null

### DIFF
--- a/fanctrl.py
+++ b/fanctrl.py
@@ -138,7 +138,7 @@ class FanController:
         sumCoreTemps = 0
         sensorsOutput = json.loads(
             subprocess.run(
-                "sensors -j",
+                "sensors -j &> /dev/null",
                 stdout=subprocess.PIPE,
                 shell=True,
                 text=True,


### PR DESCRIPTION
Modified original sensors -j call to output all to /dev/null. This prevents temp errors when something cannot be read. i.e. when Wi-Fi is disabled, this will cause an error to log to journal that "temp1_input" cannot be read for device.