### PR TITLE
Fixed a condition error for Framework 16 dGPU.

### DIFF
--- a/fanctrl.py
+++ b/fanctrl.py
@@ -196,7 +196,7 @@ class FanController:
         measurement = sumCoreTemps / cores
 
         # if we're running on a 16 AND there's a discrete GPU, compare both temperature and take the highest
-        if self.laptop_model == "16":
+        if "16" in self.laptop_model:
             for k, v in sensorsOutput.items():
                 if "junction" in v and "edge" in v:
                     dGpuTemp = v["edge"]["temp1_input"]


### PR DESCRIPTION
using `"16" in` instead of `"16" ==` as the model is either "Framework laptop 13" or "Framework laptop 16" but never "16"