### PR TITLE
Moving configuration file to /etc/fw-fanctrl (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ fabric.properties
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea/**
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo ./install.sh
 ```
 
 This bash script is going to create and enable a service that runs this repo's main script, `fanctrl.py`.
-It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `/usr/local/bin` and create a config file in `/home/<user>/.config/fw-fanctrl/config.json`
+It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `/usr/local/bin` and create a config file in `/etc/fw-fanctrl/config.json`
 
 # Update
 
@@ -34,7 +34,7 @@ sudo ./install.sh remove
 
 # Configuration
 
-There is a single `config.json` file located at `/home/<user>/.config/fw-fanctrl/config.json`.
+There is a single `config.json` file located at `/etc/fw-fanctrl/config.json`.
 
 (You will need to reload the configuration with)
 ```

--- a/config.json
+++ b/config.json
@@ -2,14 +2,7 @@
     "defaultStrategy": "lazy",
     "strategyOnDischarging" : "",
     "strategies": {
-        "sleep": {
-            "fanSpeedUpdateFrequency": 5,
-            "movingAverageInterval": 40,
-            "speedCurve": [
-                { "temp": 0, "speed": 0 }
-            ]
-        },
-        "lazyest": {
+        "laziest": {
             "fanSpeedUpdateFrequency": 5,
             "movingAverageInterval": 40,
             "speedCurve": [

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -11,8 +11,9 @@ import sys
 import threading
 from time import sleep
 
-SOCKETS_FOLDER_PATH = "/tmp/"
-COMMANDS_SOCKET_FILE_PATH = os.path.join(SOCKETS_FOLDER_PATH, ".fw-fanctrl.commands.sock")
+RESOURCE_FOLDER_PATH = "/etc/fw-fanctrl"
+DEFAULT_CONFIGURATION_FILE_PATH = os.path.join(RESOURCE_FOLDER_PATH, "config.json")
+COMMANDS_SOCKET_FILE_PATH = os.path.join(RESOURCE_FOLDER_PATH, ".fw-fanctrl.commands.sock")
 
 parser = None
 
@@ -270,7 +271,7 @@ def main():
 
     runGroup = parser.add_argument_group("run")
     runGroup.add_argument("--run", help="run the service", action="store_true")
-    runGroup.add_argument("--config", type=str, help="Path to config file", default="config.json")
+    runGroup.add_argument("--config", type=str, help="Path to config file", default=DEFAULT_CONFIGURATION_FILE_PATH)
     runGroup.add_argument(
         "--no-log", help="Disable print speed/meanTemp to stdout", action="store_true"
     )

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 /usr/local/bin/fw-fanctrl --run --config "$HOME/.config/fw-fanctrl/config.json" --no-log
+ExecStart=/usr/bin/python3 /usr/local/bin/fw-fanctrl --run --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  runuser -l "$LOGNAME" -c "fw-fanctrl --pause" ;;
-    post) runuser -l "$LOGNAME" -c "fw-fanctrl --resume" ;;
+    pre)  /usr/bin/python3 /usr/local/bin/fw-fanctrl --pause ;;
+    post) /usr/bin/python3 /usr/local/bin/fw-fanctrl --resume ;;
 esac


### PR DESCRIPTION
* removing now useless "sleep" strategy and fixing a typo in the config.json file

* moving resources to /etc/fw-fanctrl as suggested in issue comment https://github.com/TamtamHero/fw-fanctrl/issues/11#issuecomment-1436110005

removing the use of envsubst, as there is no need for environment variable replacement in services anymore

* small addition in .gitignore

* removing now useless `requirements.txt`