### PR TITLE
Installation script adaptation for package maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ It is compatible with all kinds of 13" and 16" models, both AMD/Intel CPUs and w
 
 ## Dependancies
 
-To communicate with the embedded controller the `ectool` is needed. You can either use the pre-compiled executable of `ectool` in this repo, or recompile one from [this repo](https://gitlab.howett.net/DHowett/ectool) and copy it in `./bin`.
+To communicate with the embedded controller the `ectool` is required.
+You can either use the precompiled executable of `ectool` in this repo or
+disable its installation (`--no-ectool`) and add your own by recompiling it from [this repo](https://gitlab.howett.net/DHowett/ectool) and putting it in `[prefix-dir(/usr)]/bin`.
 
 You also need to disable secure boot of your device for `ectool` to work (more details about why [here](https://www.howett.net/posts/2021-12-framework-ec/#using-fw-ectool))
 
@@ -20,12 +22,15 @@ Then run:
 sudo ./install.sh
 ```
 
-This bash script is going to create and enable a service that runs this repo's main script, `fanctrl.py`.
-It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `/usr/bin` and create a config file
+This bash script will to create and activate a service that runs this repo's main script, `fanctrl.py`.
+It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `[prefix-dir(/usr)]/bin` and create a config file
 in `/etc/fw-fanctrl/config.json`
 
-this script also includes options to disable post-install process (`--no-post-install`) and specify an installation
-directory (`--install-dir <install directory (defaults to /usr/bin)>`).
+this script also includes options to:
+- specify an installation destination directory (`--dest-dir <installation destination directory (defaults to /usr)>`).
+- specify an installation prefix directory (`--prefix-dir <installation prefix directory (defaults to /usr)>`).
+- disable ectool installation and service activation (`--no-ectool`)
+- disable post-install process (`--no-post-install`)
 
 # Update
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ sudo ./install.sh
 
 This bash script will to create and activate a service that runs this repo's main script, `fanctrl.py`.
 It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `[prefix-dir(/usr)]/bin` and create a config file
-in `/etc/fw-fanctrl/config.json`
+in `[sysconf-dir(/etc)]/fw-fanctrl/config.json`
 
 this script also includes options to:
 - specify an installation destination directory (`--dest-dir <installation destination directory (defaults to /usr)>`).
 - specify an installation prefix directory (`--prefix-dir <installation prefix directory (defaults to /usr)>`).
+- specify a default configuration directory (`--sysconf-dir <system configuration destination directory (defaults to /etc)>`).
 - disable ectool installation and service activation (`--no-ectool`)
 - disable post-install process (`--no-post-install`)
 
 # Update
 
-To install an update, you can just pull the latest commit on the `main` branch of this repository, and run the install script again.
+To install an update, you can pull the latest commit on the `main` branch of this repository, and run the install script again.
 
 # Uninstall
 ```
@@ -43,7 +44,7 @@ sudo ./install.sh --remove
 
 # Configuration
 
-There is a single `config.json` file located at `/etc/fw-fanctrl/config.json`.
+There is a single `config.json` file located at `[sysconf-dir(/etc)]/fw-fanctrl/config.json`.
 
 (You will need to reload the configuration with)
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is compatible with all kinds of 13" and 16" models, both AMD/Intel CPUs and w
 
 To communicate with the embedded controller the `ectool` is required.
 You can either use the precompiled executable of `ectool` in this repo or
-disable its installation (`--no-ectool`) and add your own by recompiling it from [this repo](https://gitlab.howett.net/DHowett/ectool) and putting it in `[prefix-dir(/usr)]/bin`.
+disable its installation (`--no-ectool`) and add your own by recompiling it from [this repo](https://gitlab.howett.net/DHowett/ectool) and putting it in `[dest-dir(/)]/bin`.
 
 You also need to disable secure boot of your device for `ectool` to work (more details about why [here](https://www.howett.net/posts/2021-12-framework-ec/#using-fw-ectool))
 
@@ -23,11 +23,11 @@ sudo ./install.sh
 ```
 
 This bash script will to create and activate a service that runs this repo's main script, `fanctrl.py`.
-It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `[prefix-dir(/usr)]/bin` and create a config file
-in `[sysconf-dir(/etc)]/fw-fanctrl/config.json`
+It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `[dest-dir(/)]/bin` and create a config file
+in `[dest-dir(/)][sysconf-dir(/etc)]/fw-fanctrl/config.json`
 
 this script also includes options to:
-- specify an installation destination directory (`--dest-dir <installation destination directory (defaults to /usr)>`).
+- specify an installation destination directory (`--dest-dir <installation destination directory (defaults to /)>`).
 - specify an installation prefix directory (`--prefix-dir <installation prefix directory (defaults to /usr)>`).
 - specify a default configuration directory (`--sysconf-dir <system configuration destination directory (defaults to /etc)>`).
 - disable ectool installation and service activation (`--no-ectool`)
@@ -44,7 +44,7 @@ sudo ./install.sh --remove
 
 # Configuration
 
-There is a single `config.json` file located at `[sysconf-dir(/etc)]/fw-fanctrl/config.json`.
+There is a single `config.json` file located at `[dest-dir(/)][sysconf-dir(/etc)]/fw-fanctrl/config.json`.
 
 (You will need to reload the configuration with)
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ sudo ./install.sh
 ```
 
 This bash script is going to create and enable a service that runs this repo's main script, `fanctrl.py`.
-It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `/usr/local/bin` and create a config file in `/etc/fw-fanctrl/config.json`
+It will copy `fanctrl.py` (to an executable file `fw-fanctrl`) and `./bin/ectool` to `/usr/bin` and create a config file
+in `/etc/fw-fanctrl/config.json`
+
+this script also includes options to disable post-install process (`--no-post-install`) and specify an installation
+directory (`--install-dir <install directory (defaults to /usr/bin)>`).
 
 # Update
 
@@ -29,7 +33,7 @@ To install an update, you can just pull the latest commit on the `main` branch o
 
 # Uninstall
 ```
-sudo ./install.sh remove
+sudo ./install.sh --remove
 ```
 
 # Configuration

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -13,7 +13,8 @@ from time import sleep
 
 RESOURCE_FOLDER_PATH = "/etc/fw-fanctrl"
 DEFAULT_CONFIGURATION_FILE_PATH = os.path.join(RESOURCE_FOLDER_PATH, "config.json")
-COMMANDS_SOCKET_FILE_PATH = os.path.join(RESOURCE_FOLDER_PATH, ".fw-fanctrl.commands.sock")
+SOCKETS_FOLDER_PATH = "/run/fw-fanctrl"
+COMMANDS_SOCKET_FILE_PATH = os.path.join(SOCKETS_FOLDER_PATH, ".fw-fanctrl.commands.sock")
 
 parser = None
 
@@ -124,6 +125,8 @@ class FanController:
         if os.path.exists(COMMANDS_SOCKET_FILE_PATH):
             os.remove(COMMANDS_SOCKET_FILE_PATH)
         try:
+            if not os.path.exists(SOCKETS_FOLDER_PATH):
+                os.makedirs(SOCKETS_FOLDER_PATH)
             server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             server_socket.bind(COMMANDS_SOCKET_FILE_PATH)
             os.chmod(COMMANDS_SOCKET_FILE_PATH, 0o777)

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -11,8 +11,7 @@ import sys
 import threading
 from time import sleep
 
-RESOURCE_FOLDER_PATH = "/etc/fw-fanctrl"
-DEFAULT_CONFIGURATION_FILE_PATH = os.path.join(RESOURCE_FOLDER_PATH, "config.json")
+DEFAULT_CONFIGURATION_FILE_PATH = "/etc/fw-fanctrl/config.json"
 SOCKETS_FOLDER_PATH = "/run/fw-fanctrl"
 COMMANDS_SOCKET_FILE_PATH = os.path.join(SOCKETS_FOLDER_PATH, ".fw-fanctrl.commands.sock")
 

--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,7 @@ function uninstall() {
         rm "$DEST_DIR/bin/ectool"
     fi
     rm -rf "/etc/fw-fanctrl"
+    rm -rf "/run/fw-fanctrl"
 
     uninstall_legacy
 }

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ function install() {
         cp "./bin/ectool" "$DEST_DIR/bin/ectool"
         chmod +x "$DEST_DIR/bin/ectool"
     fi
-    mkdir -p "/etc/fw-fanctrl"
+    mkdir -p "$SYSCONF_DIR/fw-fanctrl"
     cp "./fanctrl.py" "$DEST_DIR/bin/fw-fanctrl"
     chmod +x "$DEST_DIR/bin/fw-fanctrl"
 

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ function uninstall() {
         systemctl stop "$SERVICE" 2> "/dev/null" || true
         echo "disabling [$SERVICE]"
         systemctl disable "$SERVICE" 2> "/dev/null" || true
-        rm -rf "$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
+        rm -rf "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
     done
 
     # remove program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -102,15 +102,15 @@ function uninstall() {
         SUBCONFIGS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -type f)"
         for SUBCONFIG in $SUBCONFIGS ; do
             SUBCONFIG=$(sanitizePath "$SUBCONFIG")
-            echo "removing '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
-            rm -rf "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" 2> "/dev/null" || true
+            echo "removing '$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
+            rm -rf "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG" 2> "/dev/null" || true
         done
     done
 
-    rm "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
+    rm "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
     ectool autofanctrl 2> "/dev/null" || true # restore default fan manager
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
-        rm "$PREFIX_DIR$DEST_DIR/bin/ectool" 2> "/dev/null" || true
+        rm "$DEST_DIR$PREFIX_DIR/bin/ectool" 2> "/dev/null" || true
     fi
     rm -rf "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
     rm -rf "/run/fw-fanctrl" 2> "/dev/null" || true
@@ -121,20 +121,20 @@ function uninstall() {
 function install() {
     uninstall_legacy
 
-    mkdir -p "$PREFIX_DIR$DEST_DIR/bin"
+    mkdir -p "$DEST_DIR$PREFIX_DIR/bin"
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
-        cp "./bin/ectool" "$PREFIX_DIR$DEST_DIR/bin/ectool"
-        chmod +x "$PREFIX_DIR$DEST_DIR/bin/ectool"
+        cp "./bin/ectool" "$DEST_DIR$PREFIX_DIR/bin/ectool"
+        chmod +x "$DEST_DIR$PREFIX_DIR/bin/ectool"
     fi
     mkdir -p "$DEST_DIR$SYSCONF_DIR/fw-fanctrl"
-    cp "./fanctrl.py" "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl"
-    chmod +x "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl"
+    cp "./fanctrl.py" "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
+    chmod +x "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
 
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
     # create program services based on the services present in the './services' folder
-    echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/system'"
-    mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/system"
+    echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system'"
+    mkdir -p "$DEST_DIR$PREFIX_DIR/lib/systemd/system"
     echo "creating services"
     for SERVICE in $SERVICES ; do
         SERVICE=$(sanitizePath "$SERVICE")
@@ -142,8 +142,8 @@ function install() {
             echo "stopping [$SERVICE]"
             systemctl stop "$SERVICE"
         fi
-        echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -153,19 +153,19 @@ function install() {
         echo "adding sub-configurations for [$SERVICE]"
         SUBCONFIG_FOLDERS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)"
         # ensure folders exists
-        mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE"
+        mkdir -p "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE"
         for SUBCONFIG_FOLDER in $SUBCONFIG_FOLDERS ; do
             SUBCONFIG_FOLDER=$(sanitizePath "$SUBCONFIG_FOLDER")
-            echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER'"
-            mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER"
+            echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER'"
+            mkdir -p "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER"
         done
         SUBCONFIGS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -type f)"
         # add sub-configurations
         for SUBCONFIG in $SUBCONFIGS ; do
             SUBCONFIG=$(sanitizePath "$SUBCONFIG")
-            echo "adding '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
-            cat "$SERVICES_DIR/$SERVICE/$SUBCONFIG" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | tee "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" > "/dev/null"
-            chmod +x "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG"
+            echo "adding '$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
+            cat "$SERVICES_DIR/$SERVICE/$SUBCONFIG" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG" > "/dev/null"
+            chmod +x "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG"
         done
     done
     if [ "$SHOULD_POST_INSTALL" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ function uninstall() {
         systemctl stop "$SERVICE" 2> "/dev/null" || true
         echo "disabling [$SERVICE]"
         systemctl disable "$SERVICE" 2> "/dev/null" || true
-        rm -rf "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
+        rm -rf "$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
     done
 
     # remove program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -102,15 +102,15 @@ function uninstall() {
         SUBCONFIGS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -type f)"
         for SUBCONFIG in $SUBCONFIGS ; do
             SUBCONFIG=$(sanitizePath "$SUBCONFIG")
-            echo "removing '$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
-            rm -rf "$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" 2> "/dev/null" || true
+            echo "removing '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
+            rm -rf "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" 2> "/dev/null" || true
         done
     done
 
-    rm "$DEST_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
+    rm "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
     ectool autofanctrl 2> "/dev/null" || true # restore default fan manager
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
-        rm "$DEST_DIR/bin/ectool" 2> "/dev/null" || true
+        rm "$PREFIX_DIR$DEST_DIR/bin/ectool" 2> "/dev/null" || true
     fi
     rm -rf "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
     rm -rf "/run/fw-fanctrl" 2> "/dev/null" || true
@@ -121,20 +121,20 @@ function uninstall() {
 function install() {
     uninstall_legacy
 
-    mkdir -p "$DEST_DIR/bin"
+    mkdir -p "$PREFIX_DIR$DEST_DIR/bin"
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
-        cp "./bin/ectool" "$DEST_DIR/bin/ectool"
-        chmod +x "$DEST_DIR/bin/ectool"
+        cp "./bin/ectool" "$PREFIX_DIR$DEST_DIR/bin/ectool"
+        chmod +x "$PREFIX_DIR$DEST_DIR/bin/ectool"
     fi
     mkdir -p "$DEST_DIR$SYSCONF_DIR/fw-fanctrl"
-    cp "./fanctrl.py" "$DEST_DIR/bin/fw-fanctrl"
-    chmod +x "$DEST_DIR/bin/fw-fanctrl"
+    cp "./fanctrl.py" "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl"
+    chmod +x "$PREFIX_DIR$DEST_DIR/bin/fw-fanctrl"
 
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
     # create program services based on the services present in the './services' folder
-    echo "creating '$DEST_DIR/lib/systemd/system'"
-    mkdir -p "$DEST_DIR/lib/systemd/system"
+    echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/system'"
+    mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/system"
     echo "creating services"
     for SERVICE in $SERVICES ; do
         SERVICE=$(sanitizePath "$SERVICE")
@@ -142,8 +142,8 @@ function install() {
             echo "stopping [$SERVICE]"
             systemctl stop "$SERVICE"
         fi
-        echo "creating '$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$PREFIX_DIR$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -153,19 +153,19 @@ function install() {
         echo "adding sub-configurations for [$SERVICE]"
         SUBCONFIG_FOLDERS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)"
         # ensure folders exists
-        mkdir -p "$DEST_DIR/lib/systemd/$SERVICE"
+        mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE"
         for SUBCONFIG_FOLDER in $SUBCONFIG_FOLDERS ; do
             SUBCONFIG_FOLDER=$(sanitizePath "$SUBCONFIG_FOLDER")
-            echo "creating '$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER'"
-            mkdir -p "$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER"
+            echo "creating '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER'"
+            mkdir -p "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER"
         done
         SUBCONFIGS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -type f)"
         # add sub-configurations
         for SUBCONFIG in $SUBCONFIGS ; do
             SUBCONFIG=$(sanitizePath "$SUBCONFIG")
-            echo "adding '$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
-            cat "$SERVICES_DIR/$SERVICE/$SUBCONFIG" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" > "/dev/null"
-            chmod +x "$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG"
+            echo "adding '$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
+            cat "$SERVICES_DIR/$SERVICE/$SUBCONFIG" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | tee "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG" > "/dev/null"
+            chmod +x "$PREFIX_DIR$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG"
         done
     done
     if [ "$SHOULD_POST_INSTALL" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,7 @@ function install() {
         echo "adding sub-configurations for [$SERVICE]"
         SUBCONFIG_FOLDERS="$(cd "$SERVICES_DIR/$SERVICE" && find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)"
         # ensure folders exists
+        mkdir -p "$DEST_DIR/lib/systemd/$SERVICE"
         for SUBCONFIG_FOLDER in $SUBCONFIG_FOLDERS ; do
             SUBCONFIG_FOLDER=$(sanitizePath "$SUBCONFIG_FOLDER")
             echo "creating '$DEST_DIR/lib/systemd/$SERVICE/$SUBCONFIG_FOLDER'"

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 PREFIX_DIR="/usr"
-DEST_DIR="/usr"
+DEST_DIR=""
 SYSCONF_DIR="/etc"
 SHOULD_INSTALL_ECTOOL=true
 SHOULD_POST_INSTALL=true
@@ -112,7 +112,7 @@ function uninstall() {
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
         rm "$DEST_DIR/bin/ectool" 2> "/dev/null" || true
     fi
-    rm -rf "$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
+    rm -rf "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
     rm -rf "/run/fw-fanctrl" 2> "/dev/null" || true
 
     uninstall_legacy
@@ -126,11 +126,11 @@ function install() {
         cp "./bin/ectool" "$DEST_DIR/bin/ectool"
         chmod +x "$DEST_DIR/bin/ectool"
     fi
-    mkdir -p "$SYSCONF_DIR/fw-fanctrl"
+    mkdir -p "$DEST_DIR$SYSCONF_DIR/fw-fanctrl"
     cp "./fanctrl.py" "$DEST_DIR/bin/fw-fanctrl"
     chmod +x "$DEST_DIR/bin/fw-fanctrl"
 
-    cp -n "./config.json" "$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
+    cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
     # create program services based on the services present in the './services' folder
     echo "creating '$DEST_DIR/lib/systemd/system'"
@@ -143,7 +143,7 @@ function install() {
             systemctl stop "$SERVICE"
         fi
         echo "creating '$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%DEST_DIRECTORY%/${DEST_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -169,7 +169,7 @@ function install() {
         done
     done
     if [ "$SHOULD_POST_INSTALL" = true ]; then
-        sh "./post-install.sh" --sysconf-dir "$SYSCONF_DIR"
+        sh "./post-install.sh" --dest-dir "$DEST_DIR" --sysconf-dir "$SYSCONF_DIR"
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ function install() {
             systemctl stop "$SERVICE"
         fi
         echo "creating '$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%DEST_DIRECTORY%/${DEST_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder

--- a/post-install.sh
+++ b/post-install.sh
@@ -9,24 +9,29 @@ fi
 HOME_DIR="$(eval echo "~$(logname)")"
 
 # Argument parsing
-SHORT=s:,h
-LONG=sysconf-dir:,help
+SHORT=d:,s:,h
+LONG=dest-dir:,sysconf-dir:,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
 
+DEST_DIR="/usr"
 SYSCONF_DIR="/etc"
 
 eval set -- "$VALID_ARGS"
 while true; do
   case "$1" in
+    '--dest-dir' | '-d')
+        DEST_DIR=$2
+        shift
+        ;;
     '--sysconf-dir' | '-s')
         SYSCONF_DIR=$2
         shift
         ;;
     '--help' | '-h')
-        echo "Usage: $0 [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)]" 1>&2
+        echo "Usage: $0 [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)]" 1>&2
         exit 0
         ;;
     --)
@@ -53,7 +58,7 @@ function sanitizePath() {
 # move remaining legacy files
 function move_legacy() {
     echo "moving legacy files to their new destination"
-    (cp "$HOME_DIR/.config/fw-fanctrl"/* "$SYSCONF_DIR/fw-fanctrl/" && rm -rf "$HOME_DIR/.config/fw-fanctrl") 2> "/dev/null" || true
+    (cp "$HOME_DIR/.config/fw-fanctrl"/* "$DEST_DIR$SYSCONF_DIR/fw-fanctrl/" && rm -rf "$HOME_DIR/.config/fw-fanctrl") 2> "/dev/null" || true
 }
 
 move_legacy

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]
+  then echo "This program requires root permissions"
+  exit 1
+fi
+
+SERVICES_DIR="./services"
+SERVICE_EXTENSION=".service"
+
+SERVICES="$(cd "$SERVICES_DIR" && find . -maxdepth 1 -maxdepth 1 -type f -name "*$SERVICE_EXTENSION" -exec basename {} "$SERVICE_EXTENSION" \;)"
+
+function sanitizePath() {
+    local SANITIZED_PATH="$1"
+    local SANITIZED_PATH=${SANITIZED_PATH//..\//}
+    local SANITIZED_PATH=${SANITIZED_PATH#./}
+    local SANITIZED_PATH=${SANITIZED_PATH#/}
+    echo "$SANITIZED_PATH"
+}
+
+echo "enabling services"
+sudo systemctl daemon-reload
+for SERVICE in $SERVICES ; do
+    SERVICE=$(sanitizePath "$SERVICE")
+    echo "enabling [$SERVICE]"
+    sudo systemctl enable "$SERVICE"
+    echo "starting [$SERVICE]"
+    sudo systemctl start "$SERVICE"
+done

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%DEST_DIRECTORY%%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%DEST_DIRECTORY%%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --no-log
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 /usr/local/bin/fw-fanctrl --run --no-log
+ExecStart=/usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --run --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --run --no-log
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --no-log
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  /usr/bin/python3 /usr/local/bin/fw-fanctrl --pause ;;
-    post) /usr/bin/python3 /usr/local/bin/fw-fanctrl --resume ;;
+    pre)  /usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --pause ;;
+    post) /usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --resume ;;
 esac

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  /usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --pause ;;
-    post) /usr/bin/python3 "%DIRECTORY%/fw-fanctrl" --resume ;;
+    pre)  /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --pause ;;
+    post) /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --resume ;;
 esac


### PR DESCRIPTION
- removing user-related variable usage ($HOME)

- adapting the installation script and services to add options for package maintainers (--install-dir, --no-post-install), as well as extracting the post-install part in a separate script