### PR TITLE
Command arguments refactoring Pt.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---packaging-windows.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---packaging-windows.md
@@ -1,0 +1,37 @@
+---
+name: Bug report | packaging/windows
+about: Report a bug involving the windows packaging
+title: "[BUG] [packaging/windows]"
+labels: bug, packaging/windows
+assignees: 'leopoldhub'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Error message**
+```txt
+If applicable, add the full error message.
+```
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows 11]
+ - Version [e.g. commit 176d34b]
+ - Configuration file [config.json]
+
+**Additional context**
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 ## Additional platforms:
 
+[![Static Badge](https://img.shields.io/badge/Windows-0078D6?style=flat&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fwindows)](https://github.com/TamtamHero/fw-fanctrl/tree/packaging/windows)
+
 [![Static Badge](https://img.shields.io/badge/NixOS-5277C3?style=flat&logo=nixos&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fnix)](https://github.com/TamtamHero/fw-fanctrl/tree/packaging/nix)
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -248,9 +248,3 @@ print the selected information
 | Option             | Optional | choices       | Default | Description            |
 |--------------------|----------|---------------|---------|------------------------|
 | \<print_selection> | yes      | current, list | current | what should be printed |
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # fw-fanctrl
 
-![Static Badge](https://img.shields.io/badge/Linux%2FGlobal-FCC624?style=flat&logo=linux&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fmain)
+[![Static Badge](https://img.shields.io/badge/Linux%2FGlobal-FCC624?style=flat&logo=linux&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fmain)](https://github.com/TamtamHero/fw-fanctrl/tree/main)
 ![Static Badge](https://img.shields.io/badge/no%20binary%20blobs-30363D?style=flat&logo=GitHub-Sponsors&logoColor=4dff61)
 
-![Static Badge](https://img.shields.io/badge/Python__3.12-FFDE57?style=flat&label=Requirement&link=https%3A%2F%2Fwww.python.org%2Fdownloads)
+[![Static Badge](https://img.shields.io/badge/Python__3.12-FFDE57?style=flat&label=Requirement&link=https%3A%2F%2Fwww.python.org%2Fdownloads)](https://www.python.org/downloads)
 
 ## Additional platforms:
 
-![Static Badge](https://img.shields.io/badge/NixOS-5277C3?style=flat&logo=nixos&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fnix)
+[![Static Badge](https://img.shields.io/badge/NixOS-5277C3?style=flat&logo=nixos&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fnix)](https://github.com/TamtamHero/fw-fanctrl/tree/packaging/nix)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,91 +1,203 @@
 # fw-fanctrl
 
-This is a simple Python service for Linux that drives Framework Laptop's fan(s) speed according to a configurable speed/temp curve.
-Its default configuration targets very silent fan operation, but it's easy to configure it for a different comfort/performance trade-off.
-Its possible to specify two separate fan curves depending on whether the Laptop is charging/discharging.
-Under the hood, it uses [ectool](https://gitlab.howett.net/DHowett/ectool) to change parameters in Framework's embedded controller (EC).
+![Static Badge](https://img.shields.io/badge/Linux%2FGlobal-FCC624?style=flat&logo=linux&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fmain)
+![Static Badge](https://img.shields.io/badge/no%20binary%20blobs-30363D?style=flat&logo=GitHub-Sponsors&logoColor=4dff61)
 
-It is compatible with all kinds of 13" and 16" models, both AMD/Intel CPUs, with or without a discrete GPU.
+![Static Badge](https://img.shields.io/badge/Python__3.12-FFDE57?style=flat&label=Requirement&link=https%3A%2F%2Fwww.python.org%2Fdownloads)
+
+## Additional platforms:
+
+![Static Badge](https://img.shields.io/badge/NixOS-5277C3?style=flat&logo=nixos&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fnix)
+
+## Description
+
+Fw-fanctrl is a simple Python CLI service that controls Framework Laptop's fan(s)
+speed according to a configurable speed/temperature curve.
+
+Its default strategy aims for very quiet fan operation, but you can choose amongst the other provided strategies, or
+easily configure your own for a different comfort/performance trade-off.
+
+It also is possible to assign separate strategies depending on whether the laptop is charging or discharging.
+
+Under the hood, it uses [ectool](https://gitlab.howett.net/DHowett/ectool)
+to change parameters in Framework's embedded controller (EC).
+
+It is compatible with all 13" and 16" models, both AMD/Intel CPUs, with or without a discrete GPU.
 
 If the service is paused or stopped, the fans will revert to their default behaviour.
 
-# Install
+## Installation
 
-## Dependencies
+### Requirements
 
-To communicate with the embedded controller the `ectool` is required.
-You can either let the script download it from the [gitlab repository](https://gitlab.howett.net/DHowett/ectool) artifacts, 
-or disable its installation (`--no-ectool`) and install your own.
+| name   | version | url                                                                  |
+|--------|---------|----------------------------------------------------------------------|
+| Python | 3.12.x  | [https://www.python.org/downloads](https://www.python.org/downloads) |
 
-You also need to disable secure boot of your device for `ectool` to work (more details about why [here](https://www.howett.net/posts/2021-12-framework-ec/#using-fw-ectool))
+### Dependencies
 
-Then run:
+Dependencies are downloaded and installed automatically, but can be excluded from the installation script if you wish to
+do this manually.
+
+| name           | version   | url                                                                                  | exclusion argument |
+|----------------|-----------|--------------------------------------------------------------------------------------|--------------------|
+| DHowett@ectool | build#899 | [https://gitlab.howett.net/DHowett/ectool](https://gitlab.howett.net/DHowett/ectool) | `--no-ectool`      |
+
+### Instructions
+
+First, make sure that you have disabled secure boot in your BIOS/UEFI settings.
+(more details on why [here](https://www.howett.net/posts/2021-12-framework-ec/#using-fw-ectool))
+
+[Download the repo](https://github.com/TamtamHero/fw-fanctrl/archive/refs/heads/main.zip) and extract it manually, or
+download/clone it with the appropriate tools:
+
+```shell
+git clone "https://github.com/TamtamHero/fw-fanctrl.git"
+```
+
+```shell
+curl -L "https://github.com/TamtamHero/fw-fanctrl/archive/refs/heads/main.zip" -o "./fw-fanctrl.zip" && unzip "./fw-fanctrl.zip" -d "./fw-fanctrl" && rm -rf "./fw-fanctrl.zip"
+```
+
+Then run the installation script with administrator privileges
+
 ```bash
 sudo ./install.sh
 ```
 
-This bash script will to create and activate a service that runs this repo's main script, `fanctrl.py`.
-It will copy `fanctrl.py` (to an executable file `fw-fanctrl`), download the ectool to `[dest-dir(/)]/bin` and create a config file
-in `[dest-dir(/)][sysconf-dir(/etc)]/fw-fanctrl/config.json`
+You can add a number of arguments to the installation command to suit your needs
 
-this script also includes options to:
-- specify an installation destination directory (`--dest-dir <installation destination directory (defaults to /)>`).
-- specify an installation prefix directory (`--prefix-dir <installation prefix directory (defaults to /usr)>`).
-- specify a default configuration directory (`--sysconf-dir <system configuration destination directory (defaults to /etc)>`).
-- disable ectool installation and service activation (`--no-ectool`)
-- disable post-install process (`--no-post-install`)
-- disable pre-uninstall process (`--no-pre-uninstall`)
+| argument                                                                        | description                                        |
+|---------------------------------------------------------------------------------|----------------------------------------------------|
+| `--dest-dir <installation destination directory (defaults to /)>`               | specify an installation destination directory      |
+| `--prefix-dir <installation prefix directory (defaults to /usr)>`               | specify an installation prefix directory           |
+| `--sysconf-dir <system configuration destination directory (defaults to /etc)>` | specify a default configuration directory          |
+| `--no-ectool`                                                                   | disable ectool installation and service activation |
+| `--no-post-install`                                                             | disable post-install process                       |
+| `--no-pre-uninstall`                                                            | disable pre-uninstall process                      |
 
-# Update
+## Update
 
-To install an update, you can pull the latest commit on the `main` branch of this repository, and run the install script again.
+To update, you can download or pull the appropriate branch from this repository, and run the installation script again.
 
-# Uninstall
+## Uninstall
+
+To uninstall, run the installation script with the `--remove` argument, as well as other
+corresponding [arguments if necessary](#instructions)
+
 ```bash
 sudo ./install.sh --remove
 ```
 
-# Configuration
+## Configuration
 
-There is a single `config.json` file located at `[dest-dir(/)][sysconf-dir(/etc)]/fw-fanctrl/config.json`.
+After installation, you will find the configuration file in the following location:
 
-(You will need to reload the configuration with)
+`/etc/fw-fanctrl/config.json`
+
+If you have modified the `dest-dir` or `sysconf-dir`, here is the corresponding pattern
+
+`[dest-dir(/)][sysconf-dir(/etc)]/fw-fanctrl/config.json`
+
+It contains a list of strategies, ranked from the quietest to loudest, as well as the default and discharging
+strategies.
+
+For example, one could use a lower fan speed strategy on discharging to optimise battery life (- noise, + heat),
+and a high fan speed strategy on AC (+ noise, - heat).
+
+You can add or edit strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this
+repo :)
+
+### Default strategy
+
+The default strategy is the one used when the service is started.
+
+It can be changed by replacing the value of the `defaultStrategy` field with one of the strategies present in the
+configuration.
+
+```json
+"defaultStrategy": "[STRATEGY NAME]"
+```
+
+### Charging/Discharging strategies
+
+The discharging strategy is the one that will be used when the laptop is not on AC,
+Otherwise the default strategy is used.
+
+It can be changed by replacing the value of the `strategyOnDischarging` field with one of the strategies present in the
+configuration.
+
+```json
+"strategyOnDischarging": "[STRATEGY NAME]"
+```
+
+This is optional and can be left empty to have the same strategy at all times.
+
+### Editing strategies
+
+Strategies can be configured with the following parameters:
+
+> **SpeedCurve**:
+>
+> It is represented by the curve points for `f(temperature) = fan(s) speed`.
+>
+> ```json
+> "speedCurve": [
+>     { "temp": [TEMPERATURE POINT], "speed": [PERCENTAGE SPEED] },
+>     ...
+> ]
+> ```
+>
+> `fw-fanctrl` measures the CPU temperature, calculates a moving average of it, and then finds an appropriate `fan speed`
+> value by interpolating on the curve.
+
+> **FanSpeedUpdateFrequency**:
+>
+> It is the interval in seconds between fan speed calculations.
+>
+> ```json
+> "fanSpeedUpdateFrequency": [UPDATE FREQUENCY]
+> ```
+>
+> This is for comfort, otherwise the speed will change too often, which is noticeable and annoying, especially at low
+> speed.
+>
+> For a more responsive fan, you can reduce this setting.
+>
+> **Defaults to 5 seconds.** (minimum 1)
+
+> **MovingAverageInterval**:
+>
+> It is the number of seconds over which the moving average of temperature is calculated.
+>
+> ```json
+> "movingAverageInterval": [AVERAGING INTERVAL]
+> ```
+>
+> Increase it, and the fan speed changes more gradually. Lower it, and it becomes more responsive.
+>
+> **Defaults to 20 seconds.** (minimum 1)
+
+---
+
+Once the configuration has been changed, you must reload it with the following command
+
 ```bash
 fw-fanctrl --reload
 ```
 
-It contains different strategies, ranked from the most silent to the noisiest. It is possible to specify two different strategies for charging/discharging allowing for different optimization goals.
-On discharging one could have fan curve optimized for low fan speeds in order to save power while accepting a bit more heat. 
-On charging one could have a fan curve that focuses on keeping the CPU from throttling and the system cool, at the expense of fan noise.
-You can add new strategies, and if you think you have one that deserves to be shared, feel free to make a PR to this repo :)
+## Commands
 
-Strategies can be configured with the following parameters:
+Here is a list of commands used to interact with the service.
 
-- **SpeedCurve**:
-
-    This is the curve points for `f(temperature) = fan speed`
-
-    `fw-fanctrl` measures the CPU temperature, compute a moving average of it, and then find an appropriate `fan speed` value by interpolation on the curve.
-
-- **FanSpeedUpdateFrequency**:
-
-    Time interval between every update to the fan's speed. `fw-fanctrl` measures temperature every second and add it to its moving average, but the actual update to fan speed is controlled using this configuration. This is for comfort, otherwise the speed is changed too often and it is noticeable and annoying, especially at low speed.
-    For a more reactive fan, you can lower this setting. **Defaults to 5 seconds.**
-
-- **MovingAverageInterval**:
-
-    Number of seconds on which the moving average of temperature is computed. Increase it, and the fan speed will change more gradually. Lower it, and it will gain in reactivity. **Defaults to 20 seconds.**
-
-## Charging/Discharging strategies
-
-The strategy active by default is the one specified in the `defaultStrategy` entry. Optionally a separate strategy only active during discharge can be defined, using the `strategyOnDischarging` entry. By default no extra strategy for discharging is provided, the default strategy is active during all times.
-
-# Commands
+The commands in the `run` context are used launch the service manually.
+If you have installed it correctly, the systemd `fw-fanctrl.service` service will do this for you, so you probably will
+never need them.
 
 | Option                      | Context         | Description                                                                   |
 |-----------------------------|-----------------|-------------------------------------------------------------------------------|
 | \<strategy>                 | run & configure | the name of the strategy to use                                               |
-| --run                       | run             | run the service                                                               |
+| --run                       | run             | run the service manually                                                      |
 | --config                    | run             | specify the configuration path                                                |
 | --no-log                    | run             | disable state logging                                                         |
 | --query, -q                 | configure       | print the current strategy name                                               |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Strategies can be configured with the following parameters:
 > ]
 > ```
 >
-> `fw-fanctrl` measures the CPU temperature, calculates a moving average of it, and then finds an appropriate `fan speed`
+> `fw-fanctrl` measures the CPU temperature, calculates a moving average of it, and then finds an
+> appropriate `fan speed`
 > value by interpolating on the curve.
 
 > **FanSpeedUpdateFrequency**:
@@ -190,22 +191,68 @@ fw-fanctrl --reload
 
 ## Commands
 
-Here is a list of commands used to interact with the service.
+Here is a list of commands and options used to interact with the service.
 
-The commands in the `run` context are used launch the service manually.
+the base of all commands is the following
+
+```shell
+fw-fanctrl [commands and options]
+```
+
+First, the global options
+
+| Option                    | Optional | choices | Default | Description                                                                    |
+|---------------------------|----------|---------|---------|--------------------------------------------------------------------------------|
+| --socket-controller, --sc | yes      | unix    | unix    | the socket controller to use for communication between the cli and the service |
+
+**run**
+
+run the service manually
+
 If you have installed it correctly, the systemd `fw-fanctrl.service` service will do this for you, so you probably will
-never need them.
+never need those.
 
-| Option                      | Context         | Description                                                                   |
-|-----------------------------|-----------------|-------------------------------------------------------------------------------|
-| \<strategy>                 | run & configure | the name of the strategy to use                                               |
-| --run                       | run             | run the service manually                                                      |
-| --config                    | run             | specify the configuration path                                                |
-| --no-log                    | run             | disable state logging                                                         |
-| --query, -q                 | configure       | print the current strategy name                                               |
-| --list-strategies           | configure       | print the available strategies                                                |
-| --reload, -r                | configure       | reload the configuration file                                                 |
-| --pause                     | configure       | temporarily disable the service and reset the fans to their default behaviour |
-| --resume                    | configure       | resume the service                                                            |
-| --hardware-controller, --hc | run             | select the hardware controller. choices: ectool                               |
-| --socket-controller, --sc   | run & configure | select the socket controller. choices: unix                                   |
+| Option                      | Optional | choices        | Default              | Description                                                                       |
+|-----------------------------|----------|----------------|----------------------|-----------------------------------------------------------------------------------|
+| \<strategy>                 | yes      |                | the default strategy | the name of the strategy to use                                                   |
+| --config                    | yes      | \[CONFIG_PATH] |                      | the configuration file path                                                       |
+| --silent, -s                | yes      |                |                      | disable printing speed/temp status to stdout                                      |
+| --hardware-controller, --hc | yes      | ectool         | ectool               | the hardware controller to use for fetching and setting the temp and fan(s) speed |
+
+**use**
+
+change the current strategy
+
+| Option      | Optional | Description                     |
+|-------------|----------|---------------------------------|
+| \<strategy> | no       | the name of the strategy to use |
+
+**reset**
+
+reset to the default strategy
+
+**reload**
+
+reload the configuration file
+
+**pause**
+
+pause the service
+
+**resume**
+
+resume the service
+
+**print**
+
+print the selected information
+
+| Option             | Optional | choices       | Default | Description            |
+|--------------------|----------|---------------|---------|------------------------|
+| \<print_selection> | yes      | current, list | current | what should be printed |
+
+
+
+
+
+

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -360,8 +360,10 @@ class FanController:
                 else:
                     sleep(5)
         except InvalidStrategyException as e:
-            print("Error: missing strategy, exiting for safety reasons: " + e.args[0])
-            exit(1)
+            print(f"Missing strategy, exiting for safety reasons: {e.args[0]}")
+        except Exception as e:
+            print(f"Critical error, exiting for safety reasons: {e}")
+        exit(1)
 
 
 def main():

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -54,7 +54,7 @@ class Strategy:
 
 class Configuration:
     path = None
-    data: None
+    data = None
 
     def __init__(self, path):
         self.path = path

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -132,14 +132,14 @@ class UnixSocketController(SocketController, ABC):
                     commandReturn = commandCallback(args)
                     if not commandReturn:
                         commandReturn = "Success!"
-                    client_socket.sendall(commandReturn.encode())
+                    client_socket.sendall(commandReturn.encode('utf-8'))
                 except Exception as e:
-                    client_socket.sendall(f"[Error] > An error occurred: {e}".encode())
+                    client_socket.sendall(f"[Error] > An error occurred: {e}".encode('utf-8'))
                 finally:
                     client_socket.shutdown(socket.SHUT_WR)
                     client_socket.close()
         finally:
-            self.server_socket.close()
+            self.stopServerSocket()
 
     def stopServerSocket(self):
         if self.server_socket:
@@ -153,7 +153,7 @@ class UnixSocketController(SocketController, ABC):
         client_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             client_socket.connect(COMMANDS_SOCKET_FILE_PATH)
-            client_socket.sendall(command.encode())
+            client_socket.sendall(command.encode('utf-8'))
             received_data = b""
             while True:
                 data_chunk = client_socket.recv(1024)
@@ -162,7 +162,7 @@ class UnixSocketController(SocketController, ABC):
                 received_data += data_chunk
             # Receive data from the server
             data = received_data.decode()
-            if data.startswith("Error:"):
+            if data.startswith("[Error] > "):
                 raise Exception(data)
             return data
         finally:

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --no-log
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --pause ;;
-    post) /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --resume ;;
+    pre)  /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" pause ;;
+    post) /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" resume ;;
 esac


### PR DESCRIPTION
This PR is related to #31 .

Hi, the goal here is to refactor arguments into commands and subcommands.

Until now, there has been no restriction on the arguments used when running a command.
(we could literally use `fw-fanctrl deaf --run --config "..." --no-log --query --list-strategies --reload --pause --resume [...]` as a valid command, which makes absolutely no sense)

And as a result, we were forced to filter some of them without giving any feedback to the user (eg. if the `--run` was present, only `--sc`, `--hc`, `--config` and `<strategy>` were used).

To mitigate this, I have separated these arguments into commands and subcommands, making it impossible to use incompatible arguments at the same time.

To avoid breaking existing systems, I still kept the original argument parser, and print a warning message to the user about its deprecation.

**Here are the new commands:**

the base of all commands is the following

```shell
fw-fanctrl [commands and options]
```

First, the global options

| Option                    | Optional | choices | Default | Description                                                                    |
|---------------------------|----------|---------|---------|--------------------------------------------------------------------------------|
| --socket-controller, --sc | yes      | unix    | unix    | the socket controller to use for communication between the cli and the service |

**run**

run the service manually

If you have installed it correctly, the systemd `fw-fanctrl.service` service will do this for you, so you probably will
never need those.

| Option                      | Optional | choices        | Default              | Description                                                                       |
|-----------------------------|----------|----------------|----------------------|-----------------------------------------------------------------------------------|
| \<strategy>                 | yes      |                | the default strategy | the name of the strategy to use                                                   |
| --config                    | yes      | \[CONFIG_PATH] |                      | the configuration file path                                                       |
| --silent, -s                | yes      |                |                      | disable printing speed/temp status to stdout                                      |
| --hardware-controller, --hc | yes      | ectool         | ectool               | the hardware controller to use for fetching and setting the temp and fan(s) speed |

**use**

change the current strategy

| Option      | Optional | Description                     |
|-------------|----------|---------------------------------|
| \<strategy> | no       | the name of the strategy to use |

**reset**

reset to the default strategy

**reload**

reload the configuration file

**pause**

pause the service

**resume**

resume the service

**print**

print the selected information

| Option             | Optional | choices       | Default | Description            |
|--------------------|----------|---------------|---------|------------------------|
| \<print_selection> | yes      | current, list | current | what should be printed |
