### PR TITLE
add no battery mode for mainboards without battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can add a number of arguments to the installation command to suit your needs
 | `--no-ectool`                                                                   | disable ectool installation and service activation |
 | `--no-post-install`                                                             | disable post-install process                       |
 | `--no-pre-uninstall`                                                            | disable pre-uninstall process                      |
+| `--no-battery`                                                                  | disable checking the battery sensor in ectool      |
 
 ## Update
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ never need those.
 | --config                    | yes      | \[CONFIG_PATH] |                      | the configuration file path                                                       |
 | --silent, -s                | yes      |                |                      | disable printing speed/temp status to stdout                                      |
 | --hardware-controller, --hc | yes      | ectool         | ectool               | the hardware controller to use for fetching and setting the temp and fan(s) speed |
+| --no-battery-sensors        | yes      |                |                      | disable checking battery tempurature sensors (for mainboards without batteries)   |
 
 **use**
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can add a number of arguments to the installation command to suit your needs
 | `--no-ectool`                                                                   | disable ectool installation and service activation |
 | `--no-post-install`                                                             | disable post-install process                       |
 | `--no-pre-uninstall`                                                            | disable pre-uninstall process                      |
-| `--no-battery`                                                                  | disable checking the battery sensor in ectool      |
+| `--no-battery-sensors`                                                          | disable checking battery tempurature sensors       |
 
 ## Update
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
     "defaultStrategy": "lazy",
     "strategyOnDischarging" : "",
-    "noBatteryMode": false,
     "strategies": {
         "laziest": {
             "fanSpeedUpdateFrequency": 5,

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "defaultStrategy": "lazy",
     "strategyOnDischarging" : "",
+    "noBatteryMode": false,
     "strategies": {
         "laziest": {
             "fanSpeedUpdateFrequency": 5,

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -434,15 +434,15 @@ class HardwareController(ABC):
 
 
 class EctoolHardwareController(HardwareController, ABC):
-    noBatteryMode = False
+    noBatterySensorMode = False
     nonBatterySensors = None
     
-    def __init__(self, noBatteryMode=False):
-        self.noBatteryMode = noBatteryMode
-        if self.noBatteryMode:
-            self.getNonBatterySensors()
-    
-    def getNonBatterySensors(self):
+    def __init__(self, noBatterySensorMode=False):
+        if noBatterySensorMode:
+            self.noBatterySensorMode = True
+            self.populateNonBatterySensors()
+
+    def populateNonBatterySensors(self):
         self.nonBatterySensors = []
         rawOut = subprocess.run("ectool tempsinfo all", stdout=subprocess.PIPE, shell=True, text=True).stdout
         batterySensorsRaw = re.findall(r"\d+ Battery", rawOut, re.MULTILINE)
@@ -452,7 +452,7 @@ class EctoolHardwareController(HardwareController, ABC):
                 self.nonBatterySensors.append(x)
 
     def getTemperature(self):
-        if self.noBatteryMode:
+        if self.noBatterySensorMode:
             rawOut = "".join([
                 subprocess.run("ectool temps " + x, stdout=subprocess.PIPE, shell=True, text=True).stdout
                 for x in self.nonBatterySensors
@@ -639,9 +639,9 @@ def main():
         socketController = UnixSocketController()
 
     if args.command == "run":
-        hardwareController = EctoolHardwareController(noBatteryMode=args.no_battery_sensors)
+        hardwareController = EctoolHardwareController(noBatterySensorMode=args.no_battery_sensors)
         if args.hardware_controller == "ectool":
-            hardwareController = EctoolHardwareController(noBatteryMode=args.no_battery_sensors)
+            hardwareController = EctoolHardwareController(noBatterySensorMode=args.no_battery_sensors)
 
         fan = FanController(hardwareController=hardwareController, socketController=socketController,
                             configPath=args.config, strategyName=args.strategy)

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -311,7 +311,7 @@ class Configuration:
     
     def getNoBatteryMode(self):
         noBatteryMode = self.data.get("noBatteryMode")
-        if noBatteryMode is None or noBatteryMode is None:
+        if noBatteryMode is None or noBatteryMode is False:
             return False
         return True
 

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -453,20 +453,12 @@ class EctoolHardwareController(HardwareController, ABC):
 
     def getTemperature(self):
         if self.noBatteryMode:
-            return self.__getTemperatureNoBattery()
-        rawOut = subprocess.run("ectool temps all", stdout=subprocess.PIPE, shell=True, text=True).stdout
-        rawTemps = re.findall(r'\(= (\d+) C\)', rawOut)
-        temps = sorted([x for x in [int(x) for x in rawTemps] if x > 0], reverse=True)
-        # safety fallback to avoid damaging hardware
-        if len(temps) == 0:
-            return 50
-        return round(temps[0], 1)
-
-    def __getTemperatureNoBattery(self):
-        rawOut = "".join([
-            subprocess.run("ectool temps " + x, stdout=subprocess.PIPE, shell=True, text=True).stdout
-            for x in self.nonBatterySensors
-        ])
+            rawOut = "".join([
+                subprocess.run("ectool temps " + x, stdout=subprocess.PIPE, shell=True, text=True).stdout
+                for x in self.nonBatterySensors
+            ])
+        else:
+            rawOut = subprocess.run("ectool temps all", stdout=subprocess.PIPE, shell=True, text=True).stdout
         rawTemps = re.findall(r'\(= (\d+) C\)', rawOut)
         temps = sorted([x for x in [int(x) for x in rawTemps] if x > 0], reverse=True)
         # safety fallback to avoid damaging hardware

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ SHOULD_INSTALL_ECTOOL=true
 SHOULD_PRE_UNINSTALL=true
 SHOULD_POST_INSTALL=true
 SHOULD_REMOVE=false
-NO_BATTERY=false
+NO_BATTERY_SENSOR=false
 
 eval set -- "$VALID_ARGS"
 while true; do
@@ -54,7 +54,7 @@ while true; do
         SHOULD_POST_INSTALL=false
         ;;
     '--no-battery-sensors')
-        NO_BATTERY=true
+        NO_BATTERY_SENSOR=true
         ;;
     '--help' | '-h')
         echo "Usage: $0 [--remove,-r] [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--prefix-dir,-p <installation prefix directory (defaults to $PREFIX_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)] [--no-ectool] [--no-post-install] [--no-pre-uninstall]" 1>&2
@@ -144,7 +144,7 @@ function install() {
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
     # add --no-battery flag to the fanctrl service if specified
-    if [ "$NO_BATTERY" = true ]; then
+    if [ "$NO_BATTERY_SENSOR" = true ]; then
         origLine=$(grep "ExecStart=/usr/bin/python3" ./services/fw-fanctrl.service)
         if ! grep -q -- "--no-battery-sensors" <<< "$origLine"; then
             newLine="${origLine} --no-battery-sensors"

--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,7 @@ function install() {
     # add --no-battery flag to the fanctrl service if specified
     if [ "$NO_BATTERY" = true ]; then
         origLine=$(grep "ExecStart=/usr/bin/python3" ./services/fw-fanctrl.service)
-        if ! grep -q -- "--no-battery" <<< "$origLine"; then
+        if ! grep -q -- "--no-battery-sensors" <<< "$origLine"; then
             newLine="${origLine} --no-battery-sensors"
             sed -i "s#$origLine#$newLine#" ./services/fw-fanctrl.service
         fi

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # Argument parsing
 SHORT=r,d:,p:,s:,h
-LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,help
+LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
@@ -24,6 +24,7 @@ SHOULD_INSTALL_ECTOOL=true
 SHOULD_PRE_UNINSTALL=true
 SHOULD_POST_INSTALL=true
 SHOULD_REMOVE=false
+NO_BATTERY=false
 
 eval set -- "$VALID_ARGS"
 while true; do
@@ -51,6 +52,9 @@ while true; do
         ;;
     '--no-post-install')
         SHOULD_POST_INSTALL=false
+        ;;
+    '--no-battery')
+        NO_BATTERY=true
         ;;
     '--help' | '-h')
         echo "Usage: $0 [--remove,-r] [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--prefix-dir,-p <installation prefix directory (defaults to $PREFIX_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)] [--no-ectool] [--no-post-install] [--no-pre-uninstall]" 1>&2
@@ -137,6 +141,9 @@ function install() {
     cp "./fanctrl.py" "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
     chmod +x "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
 
+    if [ "$NO_BATTERY" = true ]; then
+        sed -i 's/"noBatteryMode": false/"noBatteryMode": true/' "./config.json"
+    fi
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
     # create program services based on the services present in the './services' folder

--- a/install.sh
+++ b/install.sh
@@ -145,11 +145,7 @@ function install() {
 
     # add --no-battery flag to the fanctrl service if specified
     if [ "$NO_BATTERY_SENSOR" = true ]; then
-        origLine=$(grep "ExecStart=/usr/bin/python3" ./services/fw-fanctrl.service)
-        if ! grep -q -- "--no-battery-sensors" <<< "$origLine"; then
-            newLine="${origLine} --no-battery-sensors"
-            sed -i "s#$origLine#$newLine#" ./services/fw-fanctrl.service
-        fi
+        NO_BATTERY_MODE_OPTION="--no-battery-sensors"
     fi
 
     # create program services based on the services present in the './services' folder
@@ -163,7 +159,7 @@ function install() {
             systemctl stop "$SERVICE"
         fi
         echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | sed -e "s/%NO_BATTERY_MODE_OPTION%/${NO_BATTERY_MODE_OPTION}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder

--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,7 @@ function install() {
 
     # add --no-battery flag to the fanctrl service if specified
     if [ "$NO_BATTERY_SENSOR" = true ]; then
-        NO_BATTERY_MODE_OPTION="--no-battery-sensors"
+        NO_BATTERY_SENSOR_OPTION="--no-battery-sensors"
     fi
 
     # create program services based on the services present in the './services' folder
@@ -159,7 +159,7 @@ function install() {
             systemctl stop "$SERVICE"
         fi
         echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | sed -e "s/%NO_BATTERY_MODE_OPTION%/${NO_BATTERY_MODE_OPTION}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PREFIX_DIRECTORY%/${PREFIX_DIR//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | sed -e "s/%NO_BATTERY_SENSOR_OPTION%/${NO_BATTERY_SENSOR_OPTION}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ function install() {
 
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
 
-    # add --no-battery flag to the fanctrl service if specified
+    # add --no-battery-sensors flag to the fanctrl service if specified
     if [ "$NO_BATTERY_SENSOR" = true ]; then
         NO_BATTERY_SENSOR_OPTION="--no-battery-sensors"
     fi

--- a/install.sh
+++ b/install.sh
@@ -141,10 +141,16 @@ function install() {
     cp "./fanctrl.py" "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
     chmod +x "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
 
-    if [ "$NO_BATTERY" = true ]; then
-        sed -i 's/"noBatteryMode": false/"noBatteryMode": true/' "./config.json"
-    fi
     cp -n "./config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
+
+    # add --no-battery flag to the fanctrl service if specified
+    if [ "$NO_BATTERY" = true ]; then
+        origLine=$(grep "ExecStart=/usr/bin/python3" ./services/fw-fanctrl.service)
+        if ! grep -q -- "--no-battery" <<< "$origLine"; then
+            newLine="${origLine} --no-battery"
+            sed -i "s#$origLine#$newLine#" ./services/fw-fanctrl.service
+        fi
+    fi
 
     # create program services based on the services present in the './services' folder
     echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system'"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # Argument parsing
 SHORT=r,d:,p:,s:,h
-LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery,help
+LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
@@ -53,7 +53,7 @@ while true; do
     '--no-post-install')
         SHOULD_POST_INSTALL=false
         ;;
-    '--no-battery')
+    '--no-battery-sensors')
         NO_BATTERY=true
         ;;
     '--help' | '-h')
@@ -147,7 +147,7 @@ function install() {
     if [ "$NO_BATTERY" = true ]; then
         origLine=$(grep "ExecStart=/usr/bin/python3" ./services/fw-fanctrl.service)
         if ! grep -q -- "--no-battery" <<< "$origLine"; then
-            newLine="${origLine} --no-battery"
+            newLine="${origLine} --no-battery-sensors"
             sed -i "s#$origLine#$newLine#" ./services/fw-fanctrl.service
         fi
     fi

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_MODE_OPTION%
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_MODE_OPTION%
+ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
if using a mainboard without a battery, like in a mounted case or as a server, ectool will error when fetching temps on the battery sensor which can be seen with this command.

```bash
ectool tempsinfo all
0: 1 F75303_Local
1: 0 F75303_CPU
2: 1 F75303_DDR
3: 3 Battery
4: 0 PECI
```

system journal errors:

```bash
Aug 18 10:04:00 hostname python3[346601]: Sensor 3 error
Aug 18 10:04:01 hostname python3[346608]: Sensor 3 error
Aug 18 10:04:02 hostname python3[346611]: Sensor 3 error
Aug 18 10:04:03 hostname python3[346614]: Sensor 3 error
Aug 18 10:04:04 hostname python3[346620]: Sensor 3 error
Aug 18 10:04:05 hostname python3[346631]: Sensor 3 error
```

this will cause an error message in journalctl once every second when fw-fanctrl calls ectool. this pr adds a config option `noBatteryMode` which will only call ectool on every sensor except for one marked as battery.