### PR TITLE
Add choice to print fan speed percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ resume the service
 
 print the selected information
 
-| Option             | Optional | Choices       | Default | Description            |
-|--------------------|----------|---------------|---------|------------------------|
-| \<print_selection> | yes      | current, list | current | what should be printed |
+| Option             | Optional | Choices              | Default | Description            |
+|--------------------|----------|----------------------|---------|------------------------|
+| \<print_selection> | yes      | current, list, speed | current | what should be printed |
+
+| Choice  | Description                      |
+|---------|----------------------------------|
+| current | The current strategy being used  |
+| list    | List available strategies        |
+| speed   | The current fan speed percentage |

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -57,6 +57,12 @@ resume the service
 
 print the selected information
 
-| Option             | Optional | Choices       | Default | Description            |
-|--------------------|----------|---------------|---------|------------------------|
-| \<print_selection> | yes      | current, list | current | what should be printed |
+| Option             | Optional | Choices              | Default | Description            |
+|--------------------|----------|----------------------|---------|------------------------|
+| \<print_selection> | yes      | current, list, speed | current | what should be printed |
+
+| Choice  | Description                      |
+|---------|----------------------------------|
+| current | The current strategy being used  |
+| list    | List available strategies        |
+| speed   | The current fan speed percentage |

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -115,11 +115,12 @@ class CommandParser:
 
         printCommand = commandsSubParser.add_parser(
             "print",
-            description="print the selected information"
+            description="print the selected information",
+            formatter_class=argparse.RawTextHelpFormatter
         )
         printCommand.add_argument(
             "print_selection",
-            help="what should be printed",
+            help="current - The current strategy\nlist - List available strategies\nspeed - The current fan speed percentage",
             nargs="?",
             type=str,
             choices=["current",

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -123,7 +123,8 @@ class CommandParser:
             nargs="?",
             type=str,
             choices=["current",
-                     "list"],
+                     "list",
+                     "speed"],
             default="current"
         )
 
@@ -564,6 +565,8 @@ class FanController:
                 return self.getCurrentStrategy().name
             elif args.print_selection == "list":
                 return '\n'.join(self.configuration.getStrategies())
+            elif args.print_selection == "speed":
+                return str(self.speed) + '%'
         return "Unknown command, unexpected."
 
     # return mean temperature over a given time interval (in seconds)


### PR DESCRIPTION
Adds an option to print the current fan speed percentage:

```
$ fw-fanctrl print speed
23%
```

Turns out adding the percentage was pretty trivial since the `FanController` holds this state. Printing the current RPM is slightly more complex since it needs to be retrieved from the hardware controller, and can be ambiguous on how to handle the case of multiple fans. But just getting the percentage satisfies my original use case

Closes #74 