### PR TITLE
Implement critical temperature

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
         "laziest": {
             "fanSpeedUpdateFrequency": 5,
             "movingAverageInterval": 40,
+            "criticalTemp": 90,
             "speedCurve": [
                 { "temp": 0, "speed": 0 },
                 { "temp": 45, "speed": 0 },
@@ -17,6 +18,7 @@
         "lazy": {
             "fanSpeedUpdateFrequency": 5,
             "movingAverageInterval": 30,
+            "criticalTemp": 90,
             "speedCurve": [
                 { "temp": 0, "speed": 15 },
                 { "temp": 50, "speed": 15 },
@@ -29,6 +31,7 @@
         "medium": {
             "fanSpeedUpdateFrequency": 5,
             "movingAverageInterval": 30,
+            "criticalTemp": 90,
             "speedCurve": [
                 { "temp": 0, "speed": 15 },
                 { "temp": 40, "speed": 15 },
@@ -41,6 +44,7 @@
         "agile": {
             "fanSpeedUpdateFrequency": 3,
             "movingAverageInterval": 15,
+            "criticalTemp": 90,
             "speedCurve": [
                 { "temp": 0, "speed": 15 },
                 { "temp": 40, "speed": 15 },
@@ -53,6 +57,7 @@
         "very-agile": {
             "fanSpeedUpdateFrequency": 2,
             "movingAverageInterval": 5,
+            "criticalTemp": 85,
             "speedCurve": [
                 { "temp": 0, "speed": 15 },
                 { "temp": 40, "speed": 15 },
@@ -65,6 +70,7 @@
         "deaf": {
             "fanSpeedUpdateFrequency": 2,
             "movingAverageInterval": 5,
+            "criticalTemp": 80,
             "speedCurve": [
                 { "temp": 0, "speed": 20 },
                 { "temp": 40, "speed": 30 },
@@ -75,6 +81,7 @@
         "aeolus": {
             "fanSpeedUpdateFrequency": 2,
             "movingAverageInterval": 5,
+            "criticalTemp": 75,
             "speedCurve": [
                 { "temp": 0, "speed": 20 },
                 { "temp": 40, "speed": 50 },

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -95,6 +95,21 @@ Strategies can be configured with the following parameters:
 >
 > **Defaults to 20 seconds.** (minimum 1)
 
+> **CriticalTemp**:
+>
+> It is a temperature after which the moving average is ignored and only the current temperature is considered.
+>
+> ```json
+> "criticalTemp": [CRITICAL TEMPERATURE]
+> ```
+>
+> Increase it, and the moving average applies for longer. Lower it, and the moving average is disabled sooner.
+>
+> If it is unset or set to null, the moving average is always considered (effectively the same as setting it to a
+> very high number).
+>
+> **Defaults to null.**
+
 ---
 
 Once the configuration has been changed, you must reload it with the following command

--- a/fanctrl.py
+++ b/fanctrl.py
@@ -267,6 +267,7 @@ class Strategy:
     name = None
     fanSpeedUpdateFrequency = None
     movingAverageInterval = None
+    criticalTemp = None
     speedCurve = None
 
     def __init__(self, name, parameters):
@@ -277,6 +278,7 @@ class Strategy:
         self.movingAverageInterval = parameters["movingAverageInterval"]
         if self.movingAverageInterval is None or self.movingAverageInterval == "":
             self.movingAverageInterval = 20
+        self.criticalTemp = parameters.get("criticalTemp")
         self.speedCurve = parameters["speedCurve"]
 
 
@@ -583,7 +585,9 @@ class FanController:
 
     def adaptSpeed(self, currentTemp):
         currentStrategy = self.getCurrentStrategy()
-        currentTemp = self.getEffectiveTemperature(currentTemp, currentStrategy.movingAverageInterval)
+        criticalTemp = currentStrategy.criticalTemp
+        if criticalTemp is not None and currentTemp < criticalTemp:
+            currentTemp = self.getEffectiveTemperature(currentTemp, currentStrategy.movingAverageInterval)
         minPoint = currentStrategy.speedCurve[0]
         maxPoint = currentStrategy.speedCurve[-1]
         for e in currentStrategy.speedCurve:


### PR DESCRIPTION
The critical temperature is a setting that can be set per-strategy ("criticalTemp") that sets a point at which the moving average is ignored and only the current temperature is used. This is done to allow having a large moving average interval without the worry that the fans will not kick in if there is a sudden spike in temperature. If the critical temperature is unset or set to null (not the string "null", but regular null in JSON), then this setting will be ignored (as if it were set to infinity).

Closes #82.