### PR TITLE
fixed help text of `fw-fanctrl use -h` to reference correct command

### DIFF
--- a/src/fw_fanctrl/CommandParser.py
+++ b/src/fw_fanctrl/CommandParser.py
@@ -88,7 +88,7 @@ class CommandParser:
         use_command = commands_sub_parser.add_parser("use", description="change the current strategy")
         use_command.add_argument(
             "strategy",
-            help='name of the strategy to use e.g: "lazy". (use `print strategies` to list available strategies)',
+            help='name of the strategy to use e.g: "lazy". (use `print list` to list available strategies)',
         )
 
         commands_sub_parser.add_parser("reset", description="reset to the default strategy")


### PR DESCRIPTION
Currently the command `fw-fanctrl use -h` prints:

```
usage: fw-fanctrl use [-h] strategy

change the current strategy

positional arguments:
  strategy    name of the strategy to use e.g: "lazy". (use `print strategies` to list available strategies)

options:
  -h, --help  show this help message and exit
```

But there is no command `fw-fanctrl print strategies`.  
This changes the help text to correctly reference `fw-fanctrl print list`