### PR TITLE
Fix Linux Mint related incompatibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Static Badge](https://img.shields.io/badge/Python%203.12-FFDE57?style=flat&label=Requirement&link=https%3A%2F%2Fwww.python.org%2Fdownloads)](https://www.python.org/downloads)
 
-## Platforms:
+## Platforms
 
 [![Static Badge](https://img.shields.io/badge/Linux%E2%80%AF%2F%E2%80%AFGlobal-FCC624?style=flat&logo=linux&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fmain)](https://github.com/TamtamHero/fw-fanctrl/tree/main)
 [![Static Badge](https://img.shields.io/badge/NixOS-5277C3?style=flat&logo=nixos&logoColor=FFFFFF&label=Platform&link=https%3A%2F%2Fgithub.com%2FTamtamHero%2Ffw-fanctrl%2Ftree%2Fpackaging%2Fnix)](https://github.com/TamtamHero/fw-fanctrl/tree/packaging/nix/doc/nix-flake.md)
@@ -38,7 +38,7 @@ If the service is paused or stopped, the fans will revert to their default behav
 
 <!-- TOC -->
 * [fw-fanctrl](#fw-fanctrl)
-  * [Platforms:](#platforms)
+  * [Platforms](#platforms)
   * [Description](#description)
   * [Table of Content](#table-of-content)
   * [Third-party projects](#third-party-projects)
@@ -57,9 +57,9 @@ If the service is paused or stopped, the fans will revert to their default behav
 
 _Have some cool project to show? Add yours to the list!_
 
-| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                           | Picture                                                                                                                                                            |
-|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [fw&#8209;fanctrl&#8209;gui](https://github.com/leopoldhub/fw-fanctrl-gui)                                       | Simple customtkinter python gui with system tray for fw&#8209;fanctrl | [<img src="https://github.com/leopoldhub/fw-fanctrl-gui/blob/master/doc/screenshots/tray.png?raw=true" width="200">](https://github.com/leopoldhub/fw-fanctrl-gui) |
+| Name                                                                                                              | Description                                                                                                         | Picture                                                                                                                                                                                                                   |
+|-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [fw&#8209;fanctrl&#8209;gui](https://github.com/leopoldhub/fw-fanctrl-gui)                                        | Simple customtkinter python gui with system tray for fw&#8209;fanctrl                                               | [<img src="https://github.com/leopoldhub/fw-fanctrl-gui/blob/master/doc/screenshots/tray.png?raw=true" width="200">](https://github.com/leopoldhub/fw-fanctrl-gui)                                                        |
 | [fw-fanctrl-revived-gnome-shell-extension](https://github.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension) | A Gnome extension that provides a convenient way to control your framework laptop fan profile when using fw-fanctrl | [<img src="https://raw.githubusercontent.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension/refs/heads/main/.github/example.png" width="200">](https://github.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension) |
 
 ## Documentation
@@ -86,6 +86,7 @@ More documentation could be found [here](./doc/README.md).
 
 | Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Version&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Url                                                                  |
 |------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| Linux kernel                                                                                                     | \>= 6.11.x                                                                                                                |                                                                      |
 | Python                                                                                                           | \>= 3.12.x                                                                                                                | [https://www.python.org/downloads](https://www.python.org/downloads) |
 
 ### Dependencies

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,20 @@ while true; do
   shift
 done
 
+if [ "$NO_PIP_INSTALL" = false ]; then
+    if ! python -m pip -h 1>/dev/null 2>&1; then
+        echo "Missing python package 'pip'!"
+        exit 1
+    fi
+fi
+
+if [ "$SHOULD_REMOVE" = false ]; then
+    if ! python -m build -h 1>/dev/null 2>&1; then
+        echo "Missing python package 'build'!"
+        exit 1
+    fi
+fi
+
 PYTHON_SCRIPT_INSTALLATION_PATH="$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
 
 # Root check

--- a/install.sh
+++ b/install.sh
@@ -171,9 +171,10 @@ function install() {
         if [[ $? -eq 0 ]]; then
             PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
         fi
-        echo "script installation path is '$PYTHON_SCRIPT_INSTALLATION_PATH'"
         rm -rf "dist/" 2> "/dev/null" || true
     fi
+
+    echo "script installation path is '$PYTHON_SCRIPT_INSTALLATION_PATH'"
 
     cp -pn "./src/fw_fanctrl/_resources/config.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
     cp -f "./src/fw_fanctrl/_resources/config.schema.json" "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
+ExecStart=/usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" pause ;;
-    post) /usr/bin/python3 "%PREFIX_DIRECTORY%/bin/fw-fanctrl" resume ;;
+    pre)  /usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" pause ;;
+    post) /usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" resume ;;
 esac


### PR DESCRIPTION
Tries to deduce the real installation path for the `fw-fanctrl` command, as some distro (e.g., Linux Mint) overrides the "--prefix" installation option.
Defaults to the expected path if not found.

Adds a Linux Kernel >= 6.11.x requirement to ensure ectool compatibility

Likely related to #107 

Closes #115 