### PR TITLE
remove unused key in json scheme

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -34,11 +34,6 @@ in
         default = defaultConfig.strategyOnDischarging;
         description = "Default strategy on discharging";
       };
-      batteryChargingStatusPath = mkOption {
-        type = str;
-        default = "/sys/class/power_supply/BAT1/status";
-        description = "";
-      };
       strategies = mkOption {
         default = defaultConfig.strategies;
         type = attrsOf (submodule (


### PR DESCRIPTION
Fixes #124 by removing an unused key from the nix module config.