### PR TITLE
Fix: handle legacy files in NO_SUDO mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -186,7 +186,9 @@ function install() {
         echo "installing python package"
         python -m pip install --prefix="$DEST_DIR$PREFIX_DIR" dist/*.tar.gz
         which python
+        set +e
         actual_installation_path="$(which 'fw-fanctrl' 2>/dev/null)"
+        set -e
         if [[ $? -eq 0 ]]; then
             PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
         fi

--- a/install.sh
+++ b/install.sh
@@ -130,7 +130,11 @@ function uninstall_legacy() {
 
 function uninstall() {
     if [ "$SHOULD_PRE_UNINSTALL" = true ]; then
-        ./pre-uninstall.sh "$([ "$NO_SUDO" = true ] && echo "--no-sudo")"
+        if ! ./pre-uninstall.sh "$([ "$NO_SUDO" = true ] && echo "--no-sudo")"; then
+            echo "Failed to run ./pre-uninstall.sh. Run the script with root permissions,"
+            echo "or skip this step by using the --no-pre-uninstall option."
+            exit 1
+        fi
     fi
     # remove program services based on the services present in the './services' folder
     echo "removing services"
@@ -242,7 +246,11 @@ function install() {
         done
     done
     if [ "$SHOULD_POST_INSTALL" = true ]; then
-        ./post-install.sh --dest-dir "$DEST_DIR" --sysconf-dir "$SYSCONF_DIR" "$([ "$NO_SUDO" = true ] && echo "--no-sudo")"
+        if ! ./post-install.sh --dest-dir "$DEST_DIR" --sysconf-dir "$SYSCONF_DIR" "$([ "$NO_SUDO" = true ] && echo "--no-sudo")"; then
+            echo "Failed to run ./post-install.sh. Run the script with root permissions,"
+            echo "or skip this step by using the --no-post-install option."
+            exit 1
+        fi
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -113,19 +113,32 @@ function sanitizePath() {
 
 function build() {
     echo "building package"
-    rm -rf "dist/" 2> "/dev/null" || true
+    remove_target "dist/"
     python -m build -s
     find . -type d -name "*.egg-info" -exec rm -rf {} + 2> "/dev/null" || true
+}
+
+# safe remove function
+function remove_target() {
+    local target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        if ! rm -rf "$target" 2> "/dev/null"; then
+            echo "Failed to remove: $target"
+            echo "Please run:"
+            echo "    sudo ./install.sh --remove"
+            exit 1
+        fi
+    fi
 }
 
 # remove remaining legacy files
 function uninstall_legacy() {
     echo "removing legacy files"
-    rm "/usr/local/bin/fw-fanctrl" 2> "/dev/null" || true
-    rm "/usr/local/bin/ectool" 2> "/dev/null" || true
-    rm "/usr/local/bin/fanctrl.py" 2> "/dev/null" || true
-    rm "/etc/systemd/system/fw-fanctrl.service" 2> "/dev/null" || true
-    rm "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
+    remove_target "/usr/local/bin/fw-fanctrl"
+    remove_target "/usr/local/bin/ectool"
+    remove_target "/usr/local/bin/fanctrl.py"
+    remove_target "/etc/systemd/system/fw-fanctrl.service"
+    remove_target "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl"
 }
 
 function uninstall() {
@@ -141,7 +154,7 @@ function uninstall() {
     for SERVICE in $SERVICES ; do
         SERVICE=$(sanitizePath "$SERVICE")
         # be EXTRA CAREFUL about the validity of the paths (dont wanna delete something important, right?... O_O)
-        rm -rf "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
+        remove_target "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION"
     done
 
     # remove program services sub-configurations based on the sub-configurations present in the './services' folder
@@ -153,7 +166,7 @@ function uninstall() {
         for SUBCONFIG in $SUBCONFIGS ; do
             SUBCONFIG=$(sanitizePath "$SUBCONFIG")
             echo "removing '$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG'"
-            rm -rf "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG" 2> "/dev/null" || true
+            remove_target "$DEST_DIR$PREFIX_DIR/lib/systemd/$SERVICE/$SUBCONFIG"
         done
     done
 
@@ -164,10 +177,10 @@ function uninstall() {
 
     ectool autofanctrl 2> "/dev/null" || true # restore default fan manager
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
-        rm "$DEST_DIR$PREFIX_DIR/bin/ectool" 2> "/dev/null" || true
+        remove_target "$DEST_DIR$PREFIX_DIR/bin/ectool"
     fi
-    rm -rf "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 2> "/dev/null" || true
-    rm -rf "/run/fw-fanctrl" 2> "/dev/null" || true
+    remove_target "$DEST_DIR$SYSCONF_DIR/fw-fanctrl" 
+    remove_target "/run/fw-fanctrl" 
 
     uninstall_legacy
 }
@@ -175,12 +188,12 @@ function uninstall() {
 function install() {
     uninstall_legacy
 
-    rm -rf "$TEMP_FOLDER"
+    remove_target "$TEMP_FOLDER"
     mkdir -p "$DEST_DIR$PREFIX_DIR/bin"
     if [ "$SHOULD_INSTALL_ECTOOL" = true ]; then
         mkdir "$TEMP_FOLDER"
         installEctool "$TEMP_FOLDER" || (echo "an error occurred when installing ectool." && echo "please check your internet connection or consider installing it manually and using --no-ectool on the installation script." && exit 1)
-        rm -rf "$TEMP_FOLDER"
+        remove_target "$TEMP_FOLDER"
     fi
     mkdir -p "$DEST_DIR$SYSCONF_DIR/fw-fanctrl"
 
@@ -196,7 +209,7 @@ function install() {
         if [[ $? -eq 0 ]]; then
             PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
         fi
-        rm -rf "dist/" 2> "/dev/null" || true
+        remove_target "dist/"
     fi
 
     echo "script installation path is '$PYTHON_SCRIPT_INSTALLATION_PATH'"

--- a/install.sh
+++ b/install.sh
@@ -121,32 +121,11 @@ function build() {
 # remove remaining legacy files
 function uninstall_legacy() {
     echo "removing legacy files"
-    if [ "$NO_SUDO" = true ]; then
-        files=(
-        "/usr/local/bin/fw-fanctrl"
-        "/usr/local/bin/ectool"
-        "/usr/local/bin/fanctrl.py"
-        "/etc/systemd/system/fw-fanctrl.service"
-        )
-        
-        for file in "${files[@]}"; do
-            if [ -e "$file" ]; then
-                if ! yes | rm "$file"; then
-                    echo "Failed to remove: $file"
-                    echo "Please run:"
-                    echo "    sudo ./install.sh --remove"
-                    exit 1
-                fi
-            fi
-        done
-        
-    else
-        rm "/usr/local/bin/fw-fanctrl" 2> "/dev/null" || true
-        rm "/usr/local/bin/ectool" 2> "/dev/null" || true
-        rm "/usr/local/bin/fanctrl.py" 2> "/dev/null" || true
-        rm "/etc/systemd/system/fw-fanctrl.service" 2> "/dev/null" || true
-        rm "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
-    fi
+    rm "/usr/local/bin/fw-fanctrl" 2> "/dev/null" || true
+    rm "/usr/local/bin/ectool" 2> "/dev/null" || true
+    rm "/usr/local/bin/fanctrl.py" 2> "/dev/null" || true
+    rm "/etc/systemd/system/fw-fanctrl.service" 2> "/dev/null" || true
+    rm "$DEST_DIR$PREFIX_DIR/bin/fw-fanctrl" 2> "/dev/null" || true
 }
 
 function uninstall() {
@@ -206,23 +185,10 @@ function install() {
     if [ "$NO_PIP_INSTALL" = false ]; then
         echo "installing python package"
         python -m pip install --prefix="$DEST_DIR$PREFIX_DIR" dist/*.tar.gz
-        if [ "$NO_SUDO" = true ]; then
-            # Attempting to uninstall fw-fanctrl (no sudo mode)
-            if ! python -m pip uninstall -y fw-fanctrl 2>/dev/null; then
-                echo
-                echo "Failed to uninstall 'fw-fanctrl'."
-                echo "You likely need root permissions to uninstall the system-installed version."
-                echo "Please run:"
-                echo "    sudo python -m pip uninstall fw-fanctrl or sudo ./install.sh --remove"
-                echo "Then re-run this installer."
-                exit 1
-            fi
-        else
-            which python
-            actual_installation_path="$(which 'fw-fanctrl' 2>/dev/null)"
-            if [[ $? -eq 0 ]]; then
-                PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
-            fi
+        which python
+        actual_installation_path="$(which 'fw-fanctrl' 2>/dev/null)"
+        if [[ $? -eq 0 ]]; then
+            PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
         fi
         rm -rf "dist/" 2> "/dev/null" || true
     fi

--- a/install.sh
+++ b/install.sh
@@ -128,18 +128,18 @@ function uninstall_legacy() {
         "/usr/local/bin/fanctrl.py"
         "/etc/systemd/system/fw-fanctrl.service"
         )
+        
         for file in "${files[@]}"; do
             if [ -e "$file" ]; then
-                error=true
+                if ! yes | rm "$file"; then
+                    echo "Failed to remove: $file"
+                    echo "Please run:"
+                    echo "    sudo ./install.sh --remove"
+                    exit 1
+                fi
             fi
         done
-
-        if [ "$error" = true ]; then
-            echo "Installation aborted due to conflicting files."
-            echo "Please run:"
-            echo "    sudo ./install.sh --remove"
-            exit 1
-        fi
+        
     else
         rm "/usr/local/bin/fw-fanctrl" 2> "/dev/null" || true
         rm "/usr/local/bin/ectool" 2> "/dev/null" || true


### PR DESCRIPTION
Fix issue 132: handle legacy files in NO_SUDO mode

---

### Summary

This pull request improves the installer to properly handle legacy files when `--no-sudo` mode is used. It prevents permission errors by detecting global legacy files or system-installed Python packages that cannot be removed without root privileges. In such cases, the installer aborts and provides clear instructions to the user on how to resolve the situation.

---

### Changes Introduced

- In `NO_SUDO=true` mode:
    - Detects global legacy binaries and service files.
    - Detects if a system-installed `fw-fanctrl` Python package exists.
    - Aborts gracefully and shows:
        - A suggested command to remove the files: `sudo ./install.sh --remove`
        - A suggested command to uninstall any system-wide `fw-fanctrl` Python package: `sudo python -m pip uninstall fw-fanctrl`
- Prevents silent failures during local installations and keeps rootless installs safe.

---
### Testing Instructions

| Scenario | Expected Outcome |
| -------- | ---------------- |
| Install with `--no-sudo` and no legacy files | Installer runs successfully |
| Install with `--no-sudo` and leftover global files | Installer aborts and tells the user to use `sudo ./install.sh --remove` |
| Install with `--no-sudo` and system-installed `fw-fanctrl` | Installer aborts and suggests using `sudo python -m pip uninstall fw-fanctrl` |
| Install with full sudo permissions | Installer behaves as usual without interruptions |

#### To test:
1. Try installing without `sudo` when old `/usr/local/bin/fw-fanctrl` exists.
2. Try installing without `sudo` when an old system-wide `fw-fanctrl` Python package is still installed.
3. Test normal installation without `--no-sudo` to verify backward compatibility.

---

### Notes

- This PR only affects users opting for `--no-sudo` installations.
- Regular users with `sudo` workflows will not be affected.