### PR TITLE
Add possibility to install via pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,17 @@ sudo ./install.sh
 
 You can add a number of arguments to the installation command to suit your needs
 
-| argument                                                                        | description                                                    |
-|---------------------------------------------------------------------------------|----------------------------------------------------------------|
-| `--dest-dir <installation destination directory (defaults to /)>`               | specify an installation destination directory                  |
-| `--prefix-dir <installation prefix directory (defaults to /usr)>`               | specify an installation prefix directory                       |
-| `--sysconf-dir <system configuration destination directory (defaults to /etc)>` | specify a default configuration directory                      |
-| `--no-ectool`                                                                   | disable ectool installation and service activation             |
-| `--no-post-install`                                                             | disable post-install process                                   |
-| `--no-pre-uninstall`                                                            | disable pre-uninstall process                                  |
-| `--no-battery-sensors`                                                          | disable checking battery temperature sensors                   |
-| `--no-pip-install`                                                              | disable the pip installation (should be done manually instead) |
+| argument                                                                        | description                                                                                     |
+|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `--dest-dir <installation destination directory (defaults to /)>`               | specify an installation destination directory                                                   |
+| `--prefix-dir <installation prefix directory (defaults to /usr)>`               | specify an installation prefix directory                                                        |
+| `--sysconf-dir <system configuration destination directory (defaults to /etc)>` | specify a default configuration directory                                                       |
+| `--no-ectool`                                                                   | disable ectool installation and service activation                                              |
+| `--no-post-install`                                                             | disable post-install process                                                                    |
+| `--no-pre-uninstall`                                                            | disable pre-uninstall process                                                                   |
+| `--no-battery-sensors`                                                          | disable checking battery temperature sensors                                                    |
+| `--no-pip-install`                                                              | disable the pip installation (should be done manually instead)                                  |
+| `--pipx`                                                                        | install using pipx instead of pip (useful if os does not allow global pip install like debian ) |
 
 ## Update
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Argument parsing
 SHORT=r,d:,p:,s:,h
-LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,help
+LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,pipx,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
@@ -22,6 +22,8 @@ SHOULD_REMOVE=false
 NO_BATTERY_SENSOR=false
 NO_SUDO=false
 NO_PIP_INSTALL=false
+DEFAULT_PYTHON_PATH="/usr/bin/python3"
+PIPX=false
 
 eval set -- "$VALID_ARGS"
 while true; do
@@ -59,8 +61,11 @@ while true; do
     '--no-pip-install')
         NO_PIP_INSTALL=true
         ;;
+    '--pipx')
+        PIPX=true
+        ;;
     '--help' | '-h')
-        echo "Usage: $0 [--remove,-r] [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--prefix-dir,-p <installation prefix directory (defaults to $PREFIX_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)] [--no-ectool] [--no-post-install] [--no-pre-uninstall] [--no-sudo] [--no-pip-install]" 1>&2
+        echo "Usage: $0 [--remove,-r] [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--prefix-dir,-p <installation prefix directory (defaults to $PREFIX_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)] [--no-ectool] [--no-post-install] [--no-pre-uninstall] [--no-sudo] [--no-pip-install] [--pipx]" 1>&2
         exit 0
         ;;
     --)
@@ -78,6 +83,13 @@ fi
 if [ "$NO_PIP_INSTALL" = false ]; then
     if ! python -m pip -h 1>/dev/null 2>&1; then
         echo "Missing python package 'pip'!"
+        exit 1
+    fi
+fi
+
+if [ "$PIPX" = true ]; then
+    if ! pipx -h >/dev/null 2>&1; then
+        echo "Missing package 'pipx'!"
         exit 1
     fi
 fi
@@ -155,7 +167,11 @@ function uninstall() {
 
     if [ "$NO_PIP_INSTALL" = false ]; then
         echo "uninstalling python package"
-        python -m pip uninstall -y fw-fanctrl 2> "/dev/null" || true
+        if [ "$PIPX" = false ]; then
+            python -m pip uninstall -y fw-fanctrl 2> "/dev/null" || true
+        else
+            pipx --global uinistall fw-fanctrl 2> "/dev/null" || true
+        fi
     fi
 
     ectool autofanctrl 2> "/dev/null" || true # restore default fan manager
@@ -184,8 +200,13 @@ function install() {
 
     if [ "$NO_PIP_INSTALL" = false ]; then
         echo "installing python package"
-        python -m pip install --prefix="$DEST_DIR$PREFIX_DIR" dist/*.tar.gz
-        which python
+        if [ "$PIPX" = false ]; then
+            python -m pip install --prefix="$DEST_DIR$PREFIX_DIR" dist/*.tar.gz
+            which python
+        else
+            pipx install --global --force dist/*.tar.gz
+            DEFAULT_PYTHON_PATH=""
+        fi
         actual_installation_path="$(which 'fw-fanctrl' 2>/dev/null)"
         if [[ $? -eq 0 ]]; then
             PYTHON_SCRIPT_INSTALLATION_PATH="$actual_installation_path"
@@ -214,7 +235,7 @@ function install() {
             systemctl stop "$SERVICE"
         fi
         echo "creating '$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION'"
-        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%PYTHON_SCRIPT_INSTALLATION_PATH%/${PYTHON_SCRIPT_INSTALLATION_PATH//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | sed -e "s/%NO_BATTERY_SENSOR_OPTION%/${NO_BATTERY_SENSOR_OPTION}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
+        cat "$SERVICES_DIR/$SERVICE$SERVICE_EXTENSION" | sed -e "s/%DEFAULT_PYTHON_PATH%/${DEFAULT_PYTHON_PATH}/" | sed -e "s/%PYTHON_SCRIPT_INSTALLATION_PATH%/${PYTHON_SCRIPT_INSTALLATION_PATH//\//\\/}/" | sed -e "s/%SYSCONF_DIRECTORY%/${SYSCONF_DIR//\//\\/}/" | sed -e "s/%NO_BATTERY_SENSOR_OPTION%/${NO_BATTERY_SENSOR_OPTION}/" | tee "$DEST_DIR$PREFIX_DIR/lib/systemd/system/$SERVICE$SERVICE_EXTENSION" > "/dev/null"
     done
 
     # add program services sub-configurations based on the sub-configurations present in the './services' folder

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
+ExecStart=%DEFAULT_PYTHON_PATH% "%PYTHON_SCRIPT_INSTALLATION_PATH%" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since some linux distros like for example debian prevent direct system wide package install via pip i adapted the installer slightly to include a "--pipx" parameter so fw-fanctrl can be installed via pix into a global venv.

This works for me and might be useful for someone else