### PR TITLE
feat(install): add specific options for packaging environments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ while true; do
   shift
 done
 
-if ! python -h 1>/dev/null 2>&1; then
+if ! python -h 1>/dev/null 2>&1 && [ "$NO_PIP_BUILD" = false ] ; then
     echo "Missing package 'python'!"
     exit 1
 fi


### PR DESCRIPTION
I wanted to use the install script so I didnt need to handle the config files and systemd units, but I ran into a few issues because the install script kept replacing the DEST_DIR with a location in `%{buildroot}` on the RPM build, this should add a few options to make this more seamless for weird enviroments like this.

- `no-pip-build`: You'd build the wheel previously on a package
- `no-override-python-installation-location`: This fixes a break on RPM builds cuz it finds %{BUILDROOT} on the script and it craps itself
