### PR TITLE
No script installation path deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ _Have some cool project to show? Add yours to the list!_
 |-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [fw&#8209;fanctrl&#8209;gui](https://github.com/leopoldhub/fw-fanctrl-gui)                                        | Simple customtkinter python gui with system tray for fw&#8209;fanctrl                                               | [<img src="https://github.com/leopoldhub/fw-fanctrl-gui/blob/master/doc/screenshots/tray.png?raw=true" width="200">](https://github.com/leopoldhub/fw-fanctrl-gui)                                                        |
 | [fw-fanctrl-revived-gnome-shell-extension](https://github.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension) | A Gnome extension that provides a convenient way to control your framework laptop fan profile when using fw-fanctrl | [<img src="https://raw.githubusercontent.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension/refs/heads/main/.github/example.png" width="200">](https://github.com/ghostdevv/fw-fanctrl-revived-gnome-shell-extension) |
-| [fw_fanctrl_applet](https://github.com/not-a-feature/fw_fanctrl_applet) | Cinnamon applet to control the framework fan-speed strategy using fw-fanctrl | [<img src="https://raw.githubusercontent.com/not-a-feature/fw_fanctrl_applet/main/screenshot.png" width="200">](https://github.com/not-a-feature/fw_fanctrl_applet)
+| [fw_fanctrl_applet](https://github.com/not-a-feature/fw_fanctrl_applet)                                           | Cinnamon applet to control the framework fan-speed strategy using fw-fanctrl                                        | [<img src="https://raw.githubusercontent.com/not-a-feature/fw_fanctrl_applet/main/screenshot.png" width="200">](https://github.com/not-a-feature/fw_fanctrl_applet)                                                       |
 
 ## Documentation
 
@@ -114,23 +114,26 @@ curl -L "https://github.com/TamtamHero/fw-fanctrl/archive/refs/heads/main.zip" -
 
 Then run the installation script with administrator privileges
 
+> ⚠ Linux Mint users, should add the `--python-prefix-dir "/usr/local"` option.
+
 ```bash
 sudo ./install.sh
 ```
 
 You can add a number of arguments to the installation command to suit your needs
 
-| argument                                                                        | description                                                                                     |
-|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `--dest-dir <installation destination directory (defaults to /)>`               | specify an installation destination directory                                                   |
-| `--prefix-dir <installation prefix directory (defaults to /usr)>`               | specify an installation prefix directory                                                        |
-| `--sysconf-dir <system configuration destination directory (defaults to /etc)>` | specify a default configuration directory                                                       |
-| `--no-ectool`                                                                   | disable ectool installation and service activation                                              |
-| `--no-post-install`                                                             | disable post-install process                                                                    |
-| `--no-pre-uninstall`                                                            | disable pre-uninstall process                                                                   |
-| `--no-battery-sensors`                                                          | disable checking battery temperature sensors                                                    |
-| `--no-pip-install`                                                              | disable the pip installation (should be done manually instead)                                  |
-| `--pipx`                                                                        | install using pipx instead of pip (useful if os does not allow global pip install like debian ) |
+| argument                                                                               | description                                                                                     |
+|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `--dest-dir <installation destination directory (defaults to /)>`                      | specify an installation destination directory                                                   |
+| `--prefix-dir <installation prefix directory (defaults to /usr)>`                      | specify an installation prefix directory                                                        |
+| `--sysconf-dir <system configuration destination directory (defaults to /etc)>`        | specify a default configuration directory                                                       |
+| `--no-ectool`                                                                          | disable ectool installation and service activation                                              |
+| `--no-post-install`                                                                    | disable post-install process                                                                    |
+| `--no-pre-uninstall`                                                                   | disable pre-uninstall process                                                                   |
+| `--no-battery-sensors`                                                                 | disable checking battery temperature sensors                                                    |
+| `--no-pip-install`                                                                     | disable the pip installation (should be done manually instead)                                  |
+| `--pipx`                                                                               | install using pipx instead of pip (useful if os does not allow global pip install like debian ) |
+| `--python-prefix-dir <python installation prefix directory (defaults to /usr)>`        | specify the python prefix directory for package installation                                    |
 
 ## Update
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fw-fanctrl"
-version = "1.0.2"
+version = "1.0.3"
 description = "A simple systemd service to better control Framework Laptop's fan(s)."
 keywords = ["framework", "laptop", "fan", "control", "cli", "service"]
 readme = "README.md"

--- a/services/fw-fanctrl.service
+++ b/services/fw-fanctrl.service
@@ -4,7 +4,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=%DEFAULT_PYTHON_PATH% "%PYTHON_SCRIPT_INSTALLATION_PATH%" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
+ExecStart="%PYTHON_SCRIPT_INSTALLATION_PATH%" --output-format "JSON" run --config "%SYSCONF_DIRECTORY%/fw-fanctrl/config.json" --silent %NO_BATTERY_SENSOR_OPTION%
 ExecStopPost=/bin/sh -c "ectool autofanctrl"
 [Install]
 WantedBy=multi-user.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case $1 in
-    pre)  /usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" pause ;;
-    post) /usr/bin/python3 "%PYTHON_SCRIPT_INSTALLATION_PATH%" resume ;;
+    pre)  "%PYTHON_SCRIPT_INSTALLATION_PATH%" pause ;;
+    post) "%PYTHON_SCRIPT_INSTALLATION_PATH%" resume ;;
 esac


### PR DESCRIPTION
This PR should solve issues #138 and #129 , which are a result of a bad fix from #116.

\> remove python paths
(using the absolute script path which includes the python executable path in its header)
\> remove the python script installation path deduction
\> add `python-prefix-dir` option for Linux Mint
\> rename `DEFAULT_PYTHON_PATH` to `PYTHON_SCRIPT_INSTALLATION_PATH`

Closes #129