### PR TITLE
Fix mint installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ curl -L "https://github.com/TamtamHero/fw-fanctrl/archive/refs/heads/main.zip" -
 
 Then run the installation script with administrator privileges
 
-> ⚠ Linux Mint users, should add the `--python-prefix-dir "/usr/local"` option.
+> ⚠ Linux Mint users, should add the `--effective-installation-dir "/usr/local/bin"` option.
 
 ```bash
 sudo ./install.sh
@@ -122,18 +122,19 @@ sudo ./install.sh
 
 You can add a number of arguments to the installation command to suit your needs
 
-| argument                                                                               | description                                                                                     |
-|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `--dest-dir <installation destination directory (defaults to /)>`                      | specify an installation destination directory                                                   |
-| `--prefix-dir <installation prefix directory (defaults to /usr)>`                      | specify an installation prefix directory                                                        |
-| `--sysconf-dir <system configuration destination directory (defaults to /etc)>`        | specify a default configuration directory                                                       |
-| `--no-ectool`                                                                          | disable ectool installation and service activation                                              |
-| `--no-post-install`                                                                    | disable post-install process                                                                    |
-| `--no-pre-uninstall`                                                                   | disable pre-uninstall process                                                                   |
-| `--no-battery-sensors`                                                                 | disable checking battery temperature sensors                                                    |
-| `--no-pip-install`                                                                     | disable the pip installation (should be done manually instead)                                  |
-| `--pipx`                                                                               | install using pipx instead of pip (useful if os does not allow global pip install like debian ) |
-| `--python-prefix-dir <python installation prefix directory (defaults to /usr)>`        | specify the python prefix directory for package installation                                    |
+| argument                                                                                          | description                                                                                     |
+|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `--dest-dir <installation destination directory (defaults to /)>`                                 | specify an installation destination directory                                                   |
+| `--prefix-dir <installation prefix directory (defaults to /usr)>`                                 | specify an installation prefix directory                                                        |
+| `--sysconf-dir <system configuration destination directory (defaults to /etc)>`                   | specify a default configuration directory                                                       |
+| `--no-ectool`                                                                                     | disable ectool installation and service activation                                              |
+| `--no-post-install`                                                                               | disable post-install process                                                                    |
+| `--no-pre-uninstall`                                                                              | disable pre-uninstall process                                                                   |
+| `--no-battery-sensors`                                                                            | disable checking battery temperature sensors                                                    |
+| `--no-pip-install`                                                                                | disable the pip installation (should be done manually instead)                                  |
+| `--pipx`                                                                                          | install using pipx instead of pip (useful if os does not allow global pip install like debian ) |
+| `--python-prefix-dir <python installation prefix directory (defaults to [dest-dir][prefix-dir])>` | specify the python prefix directory for package installation                                    |
+| `--effective-installation-dir <directory (defaults to [python-prefix-dir]/bin)>`                  | overrides the installation in which our `fw-fanctrl` executable is                              |
 
 ## Update
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ curl -L "https://github.com/TamtamHero/fw-fanctrl/archive/refs/heads/main.zip" -
 
 Then run the installation script with administrator privileges
 
-> ⚠ Linux Mint users, should add the `--effective-installation-dir "/usr/local/bin"` option.
+> ⚠ **Linux Mint** users should add the `--effective-installation-dir "/usr/local/bin"` option.
+>
+> ⚠ **Fedora Atomic desktops** users should add the `--prefix-dir "/var/usrlocal/"` option.
 
 ```bash
 sudo ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Argument parsing
 SHORT=r,d:,p:,s:,h
-LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,pipx,python-prefix-dir,help
+LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,pipx,python-prefix-dir:,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Argument parsing
 SHORT=r,d:,p:,s:,h
-LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,pipx,python-prefix-dir:,help
+LONG=remove,dest-dir:,prefix-dir:,sysconf-dir:,no-ectool,no-pre-uninstall,no-post-install,no-battery-sensors,no-sudo,no-pip-install,pipx,python-prefix-dir:,effective-installation-dir:,help
 VALID_ARGS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
@@ -24,6 +24,7 @@ NO_SUDO=false
 NO_PIP_INSTALL=false
 PIPX=false
 PYTHON_PREFIX_DIRECTORY_OVERRIDE=
+EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE=
 
 eval set -- "$VALID_ARGS"
 while true; do
@@ -68,6 +69,10 @@ while true; do
         PYTHON_PREFIX_DIRECTORY_OVERRIDE=$2
         shift
         ;;
+    '--effective-installation-dir')
+        EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE=$2
+        shift
+        ;;
     '--help' | '-h')
         echo "Usage: $0 [--remove,-r] [--dest-dir,-d <installation destination directory (defaults to $DEST_DIR)>] [--prefix-dir,-p <installation prefix directory (defaults to $PREFIX_DIR)>] [--sysconf-dir,-s system configuration destination directory (defaults to $SYSCONF_DIR)] [--no-ectool] [--no-post-install] [--no-pre-uninstall] [--no-sudo] [--no-pip-install] [--pipx] [--python-prefix-dir (defaults to $DEST_DIR$PREFIX_DIR)]" 1>&2
         exit 0
@@ -83,7 +88,13 @@ PYTHON_PREFIX_DIRECTORY="$DEST_DIR$PREFIX_DIR"
 if [ -n "$PYTHON_PREFIX_DIRECTORY_OVERRIDE" ]; then
     PYTHON_PREFIX_DIRECTORY=$PYTHON_PREFIX_DIRECTORY_OVERRIDE
 fi
-PYTHON_SCRIPT_INSTALLATION_PATH="$PYTHON_PREFIX_DIRECTORY/bin/fw-fanctrl"
+
+INSTALLATION_DIRECTORY="$PYTHON_PREFIX_DIRECTORY/bin"
+if [ -n "$EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE" ]; then
+    INSTALLATION_DIRECTORY=$EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE
+fi
+
+PYTHON_SCRIPT_INSTALLATION_PATH="$INSTALLATION_DIRECTORY/fw-fanctrl"
 
 if ! python -h 1>/dev/null 2>&1; then
     echo "Missing package 'python'!"


### PR DESCRIPTION
Linux Mint (for whatever reason...) decides to append `/local` to every single python prefix during package installation.

This leads to an invalid `/usr/local/local` python prefix when specifying `python-prefix-dir=/usr/local`.

We also cannot simply set `python-prefix-dir=/usr`, or ignore the python prefix dir entirely, because then, the expected installation path will be `/usr/bin/fw-fanctrl` which is incorrect in our situation.

So instead, I added an `effective-installation-dir` argument, and Linux Mint users should use the `--effective-installation-dir "/usr/local/bin"` option

closes #141 