### PR TITLE
Add CrOS_EC_Python as a Hardware Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ easily configure your own for a different comfort/performance trade-off.
 
 It also is possible to assign separate strategies depending on whether the laptop is charging or discharging.
 
-Under the hood, it uses [ectool](https://gitlab.howett.net/DHowett/ectool)
-to change parameters in Framework's embedded controller (EC).
+Under the hood, it uses [CrOS_EC_Python](https://github.com/Steve-Tech/CrOS_EC_Python) to change parameters in Framework's embedded controller (EC). [ectool](https://gitlab.howett.net/DHowett/ectool) can also be used as a fallback if CrOS_EC_Python is not available.
 
 It is compatible with all 13" and 16" models, both AMD/Intel CPUs, with or without a discrete GPU.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jsonschema==4.*"
+    "jsonschema==4.*",
+    "cros_ec_python==0.2.*"
 ]
 optional-dependencies = { dev = [
     "black==24.8.0",

--- a/src/fw_fanctrl/CommandParser.py
+++ b/src/fw_fanctrl/CommandParser.py
@@ -76,8 +76,8 @@ class CommandParser:
                 "--hc",
                 help="the hardware controller to use for fetching and setting the temp and fan(s) speed",
                 type=str,
-                choices=["ectool", "crosecpython"],
-                default="ectool",
+                choices=["auto", "ectool", "crosecpython"],
+                default="auto",
             )
             run_command.add_argument(
                 "--no-battery-sensors",

--- a/src/fw_fanctrl/CommandParser.py
+++ b/src/fw_fanctrl/CommandParser.py
@@ -76,7 +76,7 @@ class CommandParser:
                 "--hc",
                 help="the hardware controller to use for fetching and setting the temp and fan(s) speed",
                 type=str,
-                choices=["ectool"],
+                choices=["ectool", "crosecpython"],
                 default="ectool",
             )
             run_command.add_argument(

--- a/src/fw_fanctrl/__main__.py
+++ b/src/fw_fanctrl/__main__.py
@@ -6,8 +6,6 @@ from fw_fanctrl.FanController import FanController
 from fw_fanctrl.dto.command_result.CommandResult import CommandResult
 from fw_fanctrl.enum.CommandStatus import CommandStatus
 from fw_fanctrl.enum.OutputFormat import OutputFormat
-from fw_fanctrl.hardwareController.EctoolHardwareController import EctoolHardwareController
-from fw_fanctrl.hardwareController.CrosecpythonHardwareController import CrosecpythonHardwareController
 from fw_fanctrl.socketController.UnixSocketController import UnixSocketController
 
 
@@ -24,11 +22,21 @@ def main():
         socket_controller = UnixSocketController()
 
     if args.command == "run":
-        hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
-        if args.hardware_controller == "ectool":
-            hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
-        elif args.hardware_controller == "crosecpython":
-            hardware_controller = CrosecpythonHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
+        match args.hardware_controller:
+            case "ectool":
+                from fw_fanctrl.hardwareController.EctoolHardwareController import EctoolHardwareController
+                hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
+            case "crosecpython":
+                from fw_fanctrl.hardwareController.CrosecpythonHardwareController import CrosecpythonHardwareController
+                hardware_controller = CrosecpythonHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
+            case _:
+                # auto-detect
+                try:
+                    from fw_fanctrl.hardwareController.CrosecpythonHardwareController import CrosecpythonHardwareController
+                    hardware_controller = CrosecpythonHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
+                except ImportError:
+                    from fw_fanctrl.hardwareController.EctoolHardwareController import EctoolHardwareController
+                    hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
 
         fan = FanController(
             hardware_controller=hardware_controller,

--- a/src/fw_fanctrl/__main__.py
+++ b/src/fw_fanctrl/__main__.py
@@ -7,6 +7,7 @@ from fw_fanctrl.dto.command_result.CommandResult import CommandResult
 from fw_fanctrl.enum.CommandStatus import CommandStatus
 from fw_fanctrl.enum.OutputFormat import OutputFormat
 from fw_fanctrl.hardwareController.EctoolHardwareController import EctoolHardwareController
+from fw_fanctrl.hardwareController.CrosecpythonHardwareController import CrosecpythonHardwareController
 from fw_fanctrl.socketController.UnixSocketController import UnixSocketController
 
 
@@ -26,6 +27,8 @@ def main():
         hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
         if args.hardware_controller == "ectool":
             hardware_controller = EctoolHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
+        elif args.hardware_controller == "crosecpython":
+            hardware_controller = CrosecpythonHardwareController(no_battery_sensor_mode=args.no_battery_sensors)
 
         fan = FanController(
             hardware_controller=hardware_controller,

--- a/src/fw_fanctrl/hardwareController/CrosecpythonHardwareController.py
+++ b/src/fw_fanctrl/hardwareController/CrosecpythonHardwareController.py
@@ -1,0 +1,52 @@
+from abc import ABC
+
+from cros_ec_python import get_cros_ec
+from cros_ec_python.commands.memmap import get_temps, get_battery_values
+from cros_ec_python.commands.pwm import pwm_set_fan_duty
+from cros_ec_python.commands.thermal import temp_sensor_get_info, thermal_auto_fan_ctrl
+
+from fw_fanctrl.hardwareController.HardwareController import HardwareController
+
+
+class CrosecpythonHardwareController(HardwareController, ABC):
+    noBatterySensorMode = False
+    nonBatterySensors = None
+    ec = None
+
+    def __init__(self, no_battery_sensor_mode=False):
+        if no_battery_sensor_mode:
+            self.noBatterySensorMode = True
+            self.populate_non_battery_sensors()
+        self.ec = get_cros_ec()
+
+    def populate_non_battery_sensors(self):
+        self.nonBatterySensors = []
+        sensors = temp_sensor_get_info(self.ec)
+        for index, (name, type) in enumerate(sensors):
+            if not name.startswith("Battery"):
+                self.nonBatterySensors.append(index)
+
+    def get_temperature(self):
+        temps_raw = get_temps(self.ec)
+        if self.noBatterySensorMode:
+            temps = [temps_raw[i] for i in self.nonBatterySensors if i < len(temps_raw)]
+        else:
+            temps = temps_raw
+        # safety fallback to avoid damaging hardware
+        if len(temps) == 0:
+            return 50
+        return max(temps)
+
+    def set_speed(self, speed):
+        pwm_set_fan_duty(self.ec, speed)
+
+    def is_on_ac(self):
+        battery = get_battery_values(self.ec)
+        return battery["ac_present"]
+
+    def pause(self):
+        thermal_auto_fan_ctrl(self.ec)
+
+    def resume(self):
+        # Empty for ectool, as setting an arbitrary speed disables the automatic fan control
+        pass


### PR DESCRIPTION
Hi,
Parsing the output of `ectool` is a very inefficient way of doing things. Not just from the overhead of parsing with regex, but also since ectool was designed for debugging, `ectool temps all` will read each temperature from the memory map, then execute a command for each temp sensor to get it's info, and the fan speed; which is very unnecessary for this project. Unfortunately ECs are complicated and there wasn't much else you could do.

Over the past year or so, I've been working on [`CrOS_EC_Python`](https://github.com/Steve-Tech/CrOS_EC_Python/), which can interact with the EC directly over `/dev/cros_ec`, or using the I/O ports if needed. One of the functions CrOS_EC_Python implements is [`cros_ec_python.commands.memmap.get_temps()`](https://steve-tech.github.io/CrOS_EC_Python/cros_ec_python/commands/memmap.html#get_temps) which will only read the sensors from the memory map without transferring any commands.

Since CrOS_EC_Python is just another python package, this also means you won't have to worry about installing ectool. CrOS_EC_Python also supports FreeBSD, so fw-fanctrl may potentially also work on FreeBSD (with the required service configuration).

However, CrOS_EC_Python isn't the most tested library, it has only been thoroughly tested on my Framework 13 AMD 7840U, but is known to work on the [Framework 13 Intel 11th Gen](https://community.frame.work/t/github-steve-tech-yafi-yet-another-framework-interface/75012/4?u=steve-tech), and a Framework 16 (in the FW Discord). If you like this PR but are concerned about stability, feel free to drop commit 51328b139e03a4e36a4e8438912911eabbfd8431, and just make it an optional dependency.

Thanks,
Steve