### PR TITLE
[BUGFIX] #171 Fix installation location mismatch in fw-fanctrl.service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,8 +94,6 @@ if [ -n "$EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE" ]; then
     INSTALLATION_DIRECTORY=$EFFECTIVE_INSTALLATION_DIRECTORY_OVERRIDE
 fi
 
-PYTHON_SCRIPT_INSTALLATION_PATH="$INSTALLATION_DIRECTORY/fw-fanctrl"
-
 if ! python3 -h 1>/dev/null 2>&1; then
     echo "Missing package 'python3'!"
     exit 1
@@ -242,7 +240,13 @@ function install() {
         else
             pipx install --global --force dist/*.tar.gz
         fi
-        which 'fw-fanctrl' 2> "/dev/null" || true
+        PYTHON_SCRIPT_INSTALLATION_PATH=$(which 'fw-fanctrl' 2> "/dev/null" || true)
+        if [ -n "$PYTHON_SCRIPT_INSTALLATION_PATH" ]; then
+            echo "successfully installed at $PYTHON_SCRIPT_INSTALLATION_PATH"
+        else
+            echo "Installation failed. No installation location found. Please consider running 'sudo ./install.sh --remove', if you do not wish to proceed with the installation."
+            exit 1
+        fi
         remove_target "dist/"
     fi
 


### PR DESCRIPTION
When using the installation script, the execution path in /usr/lib/systemd/system/fw-fanctrl.service does not match with the installation location. To prevent this in the future, the install.sh script now checks where the module is installed and then modifies the systemd service file accordingly. closes #171 