### PR TITLE
feat(service): migrate away from system-sleep

### DIFF
--- a/services/fw-fanctrl-suspend.service
+++ b/services/fw-fanctrl-suspend.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Framework Fan Controller Suspend Helper
+
+[Service]
+Type=simple
+ExecStart="%PYTHON_SCRIPT_INSTALLATION_PATH%" pause
+ExecStop="%PYTHON_SCRIPT_INSTALLATION_PATH%" resume
+
+[Install]
+WantedBy=suspend.target

--- a/services/system-sleep/fw-fanctrl-suspend
+++ b/services/system-sleep/fw-fanctrl-suspend
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-case $1 in
-    pre)  "%PYTHON_SCRIPT_INSTALLATION_PATH%" pause ;;
-    post) "%PYTHON_SCRIPT_INSTALLATION_PATH%" resume ;;
-esac


### PR DESCRIPTION
From https://man7.org/linux/man-pages/man8/systemd-suspend.service.8.html: Note that scripts or binaries dropped in /usr/lib/systemd/system-sleep/ are intended for local use only and should be considered hacks.

The proposed fw-fanctrl-suspend.service should behave identically to the script inside the system-sleep directory.

Note that this was not tested as I do not have a framework device.