### PR TITLE
Fix decimal config validation for temperature thresholds

### DIFF
--- a/src/fw_fanctrl/Configuration.py
+++ b/src/fw_fanctrl/Configuration.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from json import JSONDecodeError
 from os.path import isfile
 from shutil import copyfile
@@ -25,10 +26,13 @@ class Configuration:
     def parse(self, raw_config):
         try:
             config = json.loads(raw_config)
+            validation_config = json.loads(raw_config, parse_float=Decimal)
             if "$schema" not in config:
                 original_config = json.load(ORIGINAL_CONFIG_PATH.open("r"))
                 config["$schema"] = original_config["$schema"]
-            jsonschema.Draft202012Validator(json.load(VALIDATION_SCHEMA_PATH.open("r"))).validate(config)
+                validation_config["$schema"] = original_config["$schema"]
+            validation_schema = json.load(VALIDATION_SCHEMA_PATH.open("r"), parse_float=Decimal)
+            jsonschema.Draft202012Validator(validation_schema).validate(validation_config)
             if config["defaultStrategy"] not in config["strategies"]:
                 raise ConfigurationParsingException(
                     f"Default strategy '{config["defaultStrategy"]}' is not a valid strategy."

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,49 @@
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from fw_fanctrl.Configuration import Configuration
+
+
+def parse_config(raw_config):
+    configuration = Configuration.__new__(Configuration)
+    return configuration.parse(raw_config)
+
+
+def test_two_decimal_temperature_threshold_is_valid():
+    config = parse_config(
+        """
+        {
+            "defaultStrategy": "hotonleg",
+            "strategyOnDischarging": "",
+            "strategies": {
+                "hotonleg": {
+                    "speedCurve": [
+                        {"temp": 30, "speed": 0},
+                        {"temp": 64.99, "speed": 50}
+                    ]
+                }
+            }
+        }
+        """
+    )
+
+    assert config["strategies"]["hotonleg"]["speedCurve"][1]["temp"] == 64.99
+
+
+def test_more_than_two_decimal_temperature_threshold_is_rejected():
+    with pytest.raises(ValidationError):
+        parse_config(
+            """
+            {
+                "defaultStrategy": "hotonleg",
+                "strategyOnDischarging": "",
+                "strategies": {
+                    "hotonleg": {
+                        "speedCurve": [
+                            {"temp": 64.999, "speed": 50}
+                        ]
+                    }
+                }
+            }
+            """
+        )


### PR DESCRIPTION
## Summary

Fixes #191

This fixes configuration validation for temperature thresholds such as `64.99`.

The schema allows temperatures with two decimal places via `multipleOf: 0.01`, but Python floats can make jsonschema reject valid values like `64.99` because of binary floating-point precision. The fix validates the config and schema using `Decimal` values while still returning the normal parsed configuration to the rest of the application.

## Changes

- Parse the validation copy of the user config with `parse_float=Decimal`.
- Parse the schema with `parse_float=Decimal` so `multipleOf: 0.01` is exact during validation.
- Add regression tests for:
  - accepting `64.99`
  - rejecting values with more than two decimal places, such as `64.999`

## Verification

- `python -m compileall -q src tests`
- `black --check --diff src tests`
- `pytest -q`
